### PR TITLE
Add issue triage Github workflow

### DIFF
--- a/.github/workflows/issue_triage.yml
+++ b/.github/workflows/issue_triage.yml
@@ -1,0 +1,13 @@
+name: Issue Triage
+
+on:
+  issues:
+    types:
+      - opened
+      - unlabeled
+
+jobs:
+  community-issue-triage:
+    uses: upbound/uptest/.github/workflows/issue_triage.yml@main
+    secrets:
+      UPBOUND_BOT_GITHUB_TOKEN: ${{ secrets.UPBOUND_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Add Github Actions workflow to automatically mark community issues with the `community` label.

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
