### PR TITLE
Remove manual intervention annotation from dbformysql.Server example

### DIFF
--- a/examples/dbformysql/server.yaml
+++ b/examples/dbformysql/server.yaml
@@ -2,25 +2,58 @@ apiVersion: dbformysql.azure.upbound.io/v1beta1
 kind: Server
 metadata:
   annotations:
-    upjet.upbound.io/manual-intervention: "The resource needs valid kubernetes secret."
-  name: example
+    meta.upbound.io/example-id: dbformysql/v1beta1/server
+  name: example-${Rand.RFC1123Subdomain}
 spec:
+  writeConnectionSecretToRef:
+    name: server-creds
+    namespace: upbound-system
   forProvider:
     administratorLogin: mysqladminun
     administratorLoginPasswordSecretRef:
       key: example-key
       name: example-secret
-      namespace: crossplane-system
+      namespace: upbound-system
     autoGrowEnabled: true
     backupRetentionDays: 7
     geoRedundantBackupEnabled: false
     infrastructureEncryptionEnabled: false
     location: West Europe
     publicNetworkAccessEnabled: true
-    resourceGroupNameRef:
-      name: example
+    resourceGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-dbformysql-server
     skuName: GP_Gen5_2
     sslEnforcementEnabled: true
     sslMinimalTlsVersionEnforced: TLS1_2
     storageMb: 5120
     version: "5.7"
+
+---
+
+apiVersion: azure.upbound.io/v1beta1
+kind: ResourceGroup
+metadata:
+  annotations:
+    meta.upbound.io/example-id: dbformysql/v1beta1/server
+  labels:
+    testing.upbound.io/example-name: example-dbformysql-server
+  name: resource-group-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    location: West Europe
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    meta.upbound.io/example-id: dbformysql/v1beta1/server
+  labels:
+    testing.upbound.io/example-name: example-secret
+  name: example-secret
+  namespace: upbound-system
+type: Opaque
+stringData:
+  example-key: Upbound123!-${Rand.RFC1123Subdomain}


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azure Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Removes the manual-intervention annotation from the example manifest `examples/dbformysql/server.yaml`.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Uptest: https://github.com/upbound/provider-azure/actions/runs/3733759987
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
