### PR TITLE
Improve example for `azurerm_notification_hub`

### DIFF
--- a/examples/notificationhubs/notificationhub.yaml
+++ b/examples/notificationhubs/notificationhub.yaml
@@ -2,7 +2,6 @@ apiVersion: notificationhubs.azure.upbound.io/v1beta1
 kind: NotificationHub
 metadata:
   annotations:
-    upjet.upbound.io/manual-intervention: "This resource needs a active NotificationHub Namespace."
     meta.upbound.io/example-id: notificationhubs/v1beta1/notificationhub
   labels:
     testing.upbound.io/example-name: example
@@ -10,10 +9,31 @@ metadata:
 spec:
   forProvider:
     location: West Europe
-    namespaceName: upbound
+    namespaceNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
     resourceGroupNameSelector:
       matchLabels:
         testing.upbound.io/example-name: example
+
+---
+
+apiVersion: notificationhubs.azure.upbound.io/v1beta1
+kind: NotificationHubNamespace
+metadata:
+  annotations:
+    meta.upbound.io/example-id: notificationhubs/v1beta1/notificationhub
+  labels:
+    testing.upbound.io/example-name: example
+  name: hubnamesapce
+spec:
+  forProvider:
+    location: West Europe
+    namespaceType: Messaging
+    resourceGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
+    skuName: Free
 
 ---
 
@@ -21,7 +41,6 @@ apiVersion: azure.upbound.io/v1beta1
 kind: ResourceGroup
 metadata:
   annotations:
-    upjet.upbound.io/manual-intervention: "This resource is dependency of NotificationHub."
     meta.upbound.io/example-id: notificationhubs/v1beta1/notificationhub
   labels:
     testing.upbound.io/example-name: example


### PR DESCRIPTION
### Description of your changes

This PR includes adding dependent `NotificationHubNamespace` resource to make `azurerm_notification_hub` resource uptestable.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Uptest: https://github.com/upbound/provider-azure/actions/runs/3997056974
Manuel:
```shell
NAME                                                      READY   SYNCED   EXTERNAL-NAME              AGE
resourcegroup.azure.upbound.io/example-notificationhubs   True    True     example-notificationhubs   5m42s

NAME                                                         READY   SYNCED   EXTERNAL-NAME   AGE
notificationhub.notificationhubs.azure.upbound.io/example2   True    True     example2        18m

NAME                                                                      READY   SYNCED   EXTERNAL-NAME   AGE
notificationhubnamespace.notificationhubs.azure.upbound.io/hubnamesapce   True    True     hubnamesapce    18m
```
