### PR TITLE
Adjusting linter settings to avoid misspel error for generated files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ run:
   deadline: 20m
 
   skip-files:
-  - "zz_generated\\..+\\.go$"
+  - "zz_\\..+\\.go$"
 
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azure Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adjusting misspel to avoid linter errors for autogenerated files. i.e.:
`internal/controller/zz_setup.go:252:70: `hdinsight` is a misspelling of `hindsight` (misspell)    sparkcluster "github.com/upbound/provider-azure/internal/controller/hdinsight/sparkcluster"`


I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
