### PR TITLE
Add configuration of applicationinsights(1), costmanagement(1), labservice(3), machinelearning(1), media(1), network(5), orbital(1), sentinel(1), recoveryservices(1), storage(1) groups

### DIFF
--- a/config/externalnamenottested.go
+++ b/config/externalnamenottested.go
@@ -902,4 +902,68 @@ var ExternalNameNotTestedConfigs = map[string]config.ExternalName{
 	"azurerm_private_dns_resolver_outbound_endpoint": config.TemplatedStringAsIdentifier("name", "{{ .parameters.private_dns_resolver_id }}/outboundEndpoints/{{ .external_name }}"),
 	// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Network/dnsForwardingRulesets/dnsForwardingRuleset1/virtualNetworkLinks/virtualNetworkLink1
 	"azurerm_private_dns_resolver_virtual_network_link": config.TemplatedStringAsIdentifier("name", "{{ .parameters.dns_forwarding_ruleset_id }}/virtualNetworkLinks/{{ .external_name }}"),
+
+	// applicationinsights
+	//
+	// /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Insights/webTests/appinsightswebtest
+	"azurerm_application_insights_standard_web_test": config.TemplatedStringAsIdentifier("name", "/subscriptions/{{ .setup.configuration.subscription_id }}/providers/Microsoft.Insights/webTests/{{ .external_name }}"),
+
+	// costmanagement
+	//
+	// /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CostManagement/scheduledActions/dailyanomalybyresourcegroup
+	"azurerm_cost_anomaly_alert": config.TemplatedStringAsIdentifier("name", "/subscriptions/{{ .setup.configuration.subscription_id }}/providers/Microsoft.CostManagement/scheduledActions/{{ .external_name }}"),
+
+	// labservice
+	//
+	// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.LabServices/labs/lab1
+	"azurerm_lab_service_lab": config.TemplatedStringAsIdentifier("name", "/subscriptions/{{ .setup.configuration.subscription_id }}/resourceGroups/{{ .parameters.resource_group_name }}/providers/Microsoft.LabServices/labs/{{ .external_name }}"),
+	// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.LabServices/labs/lab1/schedules/schedule1
+	"azurerm_lab_service_schedule": config.TemplatedStringAsIdentifier("name", "{{ .parameters.lab_id }}/schedules/{{ .external_name }}"),
+	// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.LabServices/labs/lab1/users/user1
+	"azurerm_lab_service_user": config.TemplatedStringAsIdentifier("name", "{{ .parameters.lab_id }}/users/{{ .external_name }}"),
+
+	// machinelearning
+	//
+	// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.MachineLearningServices/workspaces/mlw1/datastores/datastore1
+	"azurerm_machine_learning_datastore_blobstorage": config.TemplatedStringAsIdentifier("name", "{{ .parameters.workspace_id }}/datastores/{{ .external_name }}"),
+
+	// media
+	//
+	// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaServices/account1/accountFilters/filter1
+	"azurerm_media_services_account_filter": config.TemplatedStringAsIdentifier("name", "/subscriptions/{{ .setup.configuration.subscription_id }}/resourceGroups/{{ .parameters.resource_group_name }}/providers/Microsoft.Media/mediaServices/{{ .parameters.media_services_account_name }}/accountFilters/{{ .external_name }}"),
+
+	// network
+	//
+	// /providers/Microsoft.Management/managementGroups/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/networkManagerConnections/networkManagerConnection1
+	"azurerm_network_manager_management_group_connection": config.TemplatedStringAsIdentifier("name", "{{ .parameters.management_group_id }}/providers/Microsoft.Network/networkManagerConnections/{{ .external_name }}"),
+	// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Network/networkManagers/networkManager1/scopeConnections/scopeConnection1
+	"azurerm_network_manager_scope_connection": config.TemplatedStringAsIdentifier("name", "{{ .parameters.network_manager_id }}/scopeConnections/{{ .external_name }}"),
+	// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Network/networkManagers/networkManager1/networkGroups/networkGroup1/staticMembers/staticMember1
+	"azurerm_network_manager_static_member": config.TemplatedStringAsIdentifier("name", "{{ .parameters.network_group_id }}/staticMembers/{{ .external_name }}"),
+	// /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/networkManagerConnections/networkManagerConnection1
+	"azurerm_network_manager_subscription_connection": config.TemplatedStringAsIdentifier("name", "/subscriptions/{{ .setup.configuration.subscription_id }}/providers/Microsoft.Network/networkManagerConnections/{{ .external_name }}"),
+	// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/privateEndpoints/endpoints1|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/applicationSecurityGroups/securityGroup1
+	"azurerm_private_endpoint_application_security_group_association": config.IdentifierFromProvider,
+
+	// orbital
+	//
+	// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Orbital/spacecrafts/spacecraft1/contacts/contact1
+	"azurerm_orbital_contact": config.TemplatedStringAsIdentifier("name", "{{ .parameters.spacecraft_id }}/contacts/{{ .external_name }}"),
+
+	// sentinel
+	//
+	// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.OperationalInsights/workspaces/workspace1/providers/Microsoft.SecurityInsights/dataConnectors/dc1
+	"azurerm_sentinel_data_connector_threat_intelligence_taxii": config.TemplatedStringAsIdentifier("name", "{{ .parameters.log_analytics_workspace_id }}/providers/Microsoft.SecurityInsights/dataConnectors/{{ .external_name }}"),
+	// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.OperationalInsights/workspaces/workspace1/providers/Microsoft.SecurityInsights/onboardingStates/defaults
+	"azurerm_security_insights_sentinel_onboarding": config.IdentifierFromProvider,
+
+	// recoveryservices
+	//
+	// /subscriptions/00000000-0000-0000-0000-00000000000/resourceGroups/groupName/providers/Microsoft.RecoveryServices/vaults/vaultName/replicationRecoveryPlans/planName
+	"azurerm_site_recovery_replication_recovery_plan": config.TemplatedStringAsIdentifier("name", "{{ .parameters.recovery_vault_id }}/replicationRecoveryPlans/{{ .external_name }}"),
+
+	// storage
+	//
+	// /subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Storage/storageAccounts/storageAccount1/localUsers/user1
+	"azurerm_storage_account_local_user": config.TemplatedStringAsIdentifier("name", "{{ .parameters.storage_account_id }}/localUsers/{{ .external_name }}"),
 }


### PR DESCRIPTION


<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Add external name configuration without testing:

* applicationinsights
  * [x] [azurerm_application_insights_standard_web_test](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights_standard_web_test)

* costmanagement  
  * [x] [azurerm_cost_anomaly_alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cost_anomaly_alert)

* labservice 
  * [x] [azurerm_lab_service_lab](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lab_service_lab)
  * [x] [azurerm_lab_service_schedule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lab_service_schedule)
  * [x] [azurerm_lab_service_user](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lab_service_user)

* machinelearning
  * [x] [azurerm_machine_learning_datastore_blobstorage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/machine_learning_datastore_blobstorage)

* media
  * [x] [azurerm_media_services_account_filter](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/media_services_account_filter)

* network 
  * [x] [azurerm_network_manager_management_group_connection](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_manager_management_group_connection)
  * [x] [azurerm_network_manager_scope_connection](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_manager_scope_connection)
  * [x] [azurerm_network_manager_static_member](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_manager_static_member)
  * [x] [azurerm_network_manager_subscription_connection](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_manager_subscription_connection)
  * [x] [azurerm_private_endpoint_application_security_group_association](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint_application_security_group_association)

* orbital 
  * [x] [azurerm_orbital_contact](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/orbital_contact)

* sentinel 
  * [x] [azurerm_sentinel_data_connector_threat_intelligence_taxii](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/sentinel_data_connector_threat_intelligence_taxii)
  * [x] [azurerm_sentinel_log_analytics_workspace_onboarding](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/sentinel_log_analytics_workspace_onboarding)

* recoveryservices
  * [x] [azurerm_site_recovery_replication_recovery_plan](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/site_recovery_replication_recovery_plan)

* storage
  * [x] [azurerm_storage_account_local_user](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account_local_user)
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azure Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #337 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
