### PR TITLE
Adding 5 resoures to ignore list

### DIFF
--- a/config/externalnamenottested.go
+++ b/config/externalnamenottested.go
@@ -122,8 +122,6 @@ var ExternalNameNotTestedConfigs = map[string]config.ExternalName{
 	"azurerm_automation_connection_classic_certificate": config.TemplatedStringAsIdentifier("name", "/subscriptions/{{ .setup.configuration.subscription_id }}/resourceGroups/{{ .parameters.resource_group_name }}/providers/Microsoft.Automation/automationAccounts/{{ .parameters.automation_account_name }}/connections/{{ .external_name }}"),
 	// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Automation/automationAccounts/account1/connections/conn1
 	"azurerm_automation_connection_service_principal": config.TemplatedStringAsIdentifier("name", "/subscriptions/{{ .setup.configuration.subscription_id }}/resourceGroups/{{ .parameters.resource_group_name }}/providers/Microsoft.Automation/automationAccounts/{{ .parameters.automation_account_name }}/connections/{{ .external_name }}"),
-	// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Automation/automationAccounts/account1/nodeConfigurations/configuration1
-	"azurerm_automation_dsc_nodeconfiguration": config.TemplatedStringAsIdentifier("name", "/subscriptions/{{ .setup.configuration.subscription_id }}/resourceGroups/{{ .parameters.resource_group_name }}/providers/Microsoft.Automation/automationAccounts/{{ .parameters.automation_account_name }}/nodeConfigurations/{{ .external_name }}"),
 
 	// botservice
 	//
@@ -332,12 +330,6 @@ var ExternalNameNotTestedConfigs = map[string]config.ExternalName{
 	// /subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.StoragePool/diskPools/pool1/iscsiTargets/iscsiTarget1
 	// SKIP LIST: Azure are officially halting the preview of Azure Disk Pools, and it will not be made generally available.
 	"azurerm_disk_pool_iscsi_target": config.TemplatedStringAsIdentifier("name", "{{ .parameters.disks_pool_id }}/iscsiTargets/{{ .external_name }}"),
-
-	// recoveryservices
-	//
-	// Site Recovery Replicated VM's can be imported using the resource id
-	// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-group-name/providers/Microsoft.RecoveryServices/vaults/recovery-vault-name/replicationFabrics/fabric-name/replicationProtectionContainers/protection-container-name/replicationProtectedItems/vm-replication-name
-	"azurerm_site_recovery_replicated_vm": config.TemplatedStringAsIdentifier("name", "/subscriptions/{{ .setup.configuration.subscription_id }}/resourceGroups/{{ .parameters.resource_group_name }}/providers/Microsoft.RecoveryServices/vaults/{{ .parameters.recovery_vault_name }}/replicationFabrics/{{ .parameters.source_recovery_fabric_name }}/replicationProtectionContainers/{{ .parameters.source_recovery_protection_container_name }}/replicationProtectedItems/{{ .external_name }}"),
 
 	// resources
 	//
@@ -571,8 +563,6 @@ var ExternalNameNotTestedConfigs = map[string]config.ExternalName{
 
 	// storage
 	//
-	// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StorageSync/storageSyncServices/sync1/syncGroups/syncgroup1/cloudEndpoints/cloudEndpoint1
-	"azurerm_storage_sync_cloud_endpoint": config.TemplatedStringAsIdentifier("name", "{{ .parameters.storage_sync_group_id }}/cloudEndpoints/{{ .external_name }}"),
 	// https://example.table.core.windows.net/table1(PartitionKey='samplepartition',RowKey='samplerow')
 	"azurerm_storage_table_entity": config.IdentifierFromProvider,
 
@@ -582,13 +572,6 @@ var ExternalNameNotTestedConfigs = map[string]config.ExternalName{
 	"azurerm_stream_analytics_job_schedule": config.TemplatedStringAsIdentifier("", "{{ .parameters.stream_analytics_job_id }}/schedule/default"),
 	// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1/inputs/input1
 	"azurerm_stream_analytics_stream_input_eventhub_v2": config.TemplatedStringAsIdentifier("name", "{{ .parameters.stream_analytics_job_id }}/inputs/{{ .external_name }}"),
-
-	// virtual_desktop
-	//
-	// /subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/hostPools/pool1/registrationInfo/default
-	"azurerm_virtual_desktop_host_pool_registration_info": config.TemplatedStringAsIdentifier("", "{{ .parameters.hostpool_id }}/registrationInfo/default"),
-	// /subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/scalingPlans/plan1
-	"azurerm_virtual_desktop_scaling_plan": config.TemplatedStringAsIdentifier("name", "/subscriptions/{{ .setup.configuration.subscription_id }}/resourceGroups/{{ .parameters.resource_group_name }}/providers/Microsoft.DesktopVirtualization/scalingPlans/{{ .external_name }}"),
 
 	// virtual_machine
 	//

--- a/config/provider.go
+++ b/config/provider.go
@@ -95,6 +95,7 @@ var skipList = []string{
 	"azurerm_dedicated_host_group",
 	"azurerm_storage_disks_pool",
 	"azurerm_storage_sync_group",
+	"azurerm_storage_sync_cloud_endpoint", // depends on azurerm_storage_sync_group
 	"azurerm_virtual_desktop_application_group",
 	// associated with non-generated
 	"azurerm_virtual_desktop_workspace_application_group_association",
@@ -119,10 +120,13 @@ var skipList = []string{
 	"azurerm_sql_database",
 	"azurerm_sql_elasticpool",
 	"azurerm_sql_firewall_rule",
+	"azurerm_site_recovery_replicated_vm", // depends on azurerm_virtual_machine
 	// irrelevant
 	"azurerm_virtual_desktop_application",
 	"azurerm_virtual_desktop_host_pool",
 	"azurerm_virtual_desktop_workspace",
+	"azurerm_virtual_desktop_scaling_plan",                // depends on azurerm_virtual_desktop_host_pool
+	"azurerm_virtual_desktop_host_pool_registration_info", // depends on azurerm_virtual_desktop_host_pool
 	// other upjet issues
 	"azurerm_container_registry_task",
 	"azurerm_dashboard",
@@ -138,6 +142,7 @@ var skipList = []string{
 	"azurerm_log_analytics_storage_insights",
 	"azurerm_virtual_hub_bgp_connection",
 	"azurerm_automation_dsc_configuration",
+	"azurerm_automation_dsc_nodeconfiguration", // depends on azurerm_automation_dsc_configuration
 	"azurerm_monitor_log_profile",
 	"azurerm_machine_learning_inference_cluster",
 	"azurerm_sql_failover_group",


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azure Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #381 
`virtual_desktop` (2) 
 * [azurerm_virtual_desktop_scaling_plan](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_desktop_scaling_plan)
 * [azurerm_virtual_desktop_host_pool_registration_info](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_desktop_host_pool_registration_info)
Both depend on [irrelevant resource]( https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_desktop_host_pool), provider.go [link](https://github.com/upbound/provider-azure/blob/main/config/provider.go#L124)

`storage` (1)  
  *  [azurerm_storage_sync_cloud_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_sync_cloud_endpoint)
Depends on ignored resource. Provider.go [link](https://github.com/upbound/provider-azure/blob/main/config/provider.go#L97)

`automation` (1)  
* [azurerm_automation_dsc_nodeconfiguration](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_dsc_nodeconfiguration)
Depends on **azurerm_automation_dsc_configuration**, ignored in [provider.go](https://github.com/upbound/provider-azure/blob/main/config/provider.go#L140)

`recoveryservices` (1)
* [`azurerm_site_recovery_replicated_vm`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/site_recovery_replicated_vm)
Depends on azurerm_virtual_machine, provider.go [link](https://github.com/upbound/provider-azure/blob/main/config/provider.go#L107). 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
