### PR TITLE
Fix issue 276: Double encoded KubernetesCluster connection secrets

### DIFF
--- a/config/common/common.go
+++ b/config/common/common.go
@@ -25,6 +25,8 @@ import (
 	tjconfig "github.com/upbound/upjet/pkg/config"
 
 	"github.com/upbound/provider-azure/apis/rconfig"
+
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 )
 
 const (
@@ -148,4 +150,11 @@ func addReference(references tjconfig.References, referenceKind, referenceName, 
 			Extractor: rconfig.ExtractResourceIDFuncPath,
 		}
 	}
+}
+
+// GetField returns the value of field as a string in a map[string]interface{},
+//
+//	fails properly otherwise.
+func GetField(from map[string]interface{}, path string) (string, error) {
+	return fieldpath.Pave(from).GetString(path)
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azure Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes first part for issue https://github.com/upbound/provider-azure/issues/276

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Manually
Uptest: https://github.com/upbound/provider-azure/actions/runs/5268824377

Secret before the changes:
[before_fix_changes.txt](https://github.com/upbound/provider-azure/files/11847077/before_fix_changes.txt)

Secret after the changes:
[after_changed.txt](https://github.com/upbound/provider-azure/files/11847085/after_changed.txt)


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
