### PR TITLE
Add caller workflow for publishing docs

### DIFF
--- a/.github/workflows/updoc.yml
+++ b/.github/workflows/updoc.yml
@@ -1,0 +1,10 @@
+name: Updoc
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  publish-docs:
+    uses: upbound/uptest/.github/workflows/provider-updoc.yml@main
+    secrets:
+      UPBOUND_CI_PROD_BUCKET_SA: ${{ secrets.UPBOUND_CI_PROD_BUCKET_SA }}


### PR DESCRIPTION
### Description of your changes

Consumes reusable workflows introduced in https://github.com/upbound/uptest/pull/85

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Manually tested on `turkenf/uptest` and `turkenf/provider-azure`