### PR TITLE
Add caller workflow for publishing service artifacts

### DIFF
--- a/.github/workflows/publish-service-artifacts.yml
+++ b/.github/workflows/publish-service-artifacts.yml
@@ -1,0 +1,17 @@
+name: Publish Service Artifacts
+
+on:
+  workflow_dispatch: 
+    inputs:
+      subpackages:
+        description: 'Subpackages to be built individually (e.g. monolith config ec2)'
+        required: true
+
+jobs:
+  publish-service-artifacts:
+    uses: upbound/uptest/.github/workflows/provider-publish-service-artifacts.yml@main
+    with:
+      subpackages: ${{ github.event.inputs.subpackages }}
+    secrets:
+      UPBOUND_MARKETPLACE_PUSH_ROBOT_USR: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
+      UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW }}


### PR DESCRIPTION
### Description of your changes

Consumes reusable workflows introduced in https://github.com/upbound/uptest/pull/94

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually tested on `turkenf/uptest` and `turkenf/provider-azure`
