### PR TITLE
Use monolith for local run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ submodules:
 run: go.build
 	@$(INFO) Running Crossplane locally out-of-cluster . . .
 	@# To see other arguments that can be provided, run the command with --help instead
-	UPBOUND_CONTEXT="local" $(GO_OUT_DIR)/provider --debug
+	UPBOUND_CONTEXT="local" $(GO_OUT_DIR)/monolith --debug
 
 # NOTE(hasheddan): we ensure up is installed prior to running platform-specific
 # build steps in parallel to avoid encountering an installation race condition.


### PR DESCRIPTION
### Description of your changes

This PR includes using `monolith` package instead of `provider` in local run.
Relevant PR: https://github.com/upbound/provider-aws/pull/687

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.
