### PR TITLE
Remove manual-intervention from `MSSQLServerDNSAlias` resource

### DIFF
--- a/examples/sql/mssqlfailovergroup.yaml
+++ b/examples/sql/mssqlfailovergroup.yaml
@@ -19,7 +19,9 @@ apiVersion: sql.azure.upbound.io/v1beta1
 kind: MSSQLServerDNSAlias
 metadata:
   annotations:
-    upjet.upbound.io/manual-intervention: "Creation fails, see https://github.com/upbound/official-providers/issues/364"
+    meta.upbound.io/example-id: sql/v1beta1/mssqlfailovergroup
+  labels:
+    testing.upbound.io/example-name: example
   name: ${Rand.RFC1123Subdomain}
 spec:
   forProvider:
@@ -146,7 +148,7 @@ metadata:
   name: example-sql-failover-primary-${Rand.RFC1123Subdomain}
 spec:
   forProvider:
-    location: North Europe
+    location: West Europe
 
 ---
 


### PR DESCRIPTION
### Description of your changes

In this PR, manual-intervention has been removed from the `MSSQLServerDNSAlias` resource.

Fixes: https://github.com/upbound/provider-azure/issues/27

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Uptest: https://github.com/upbound/provider-azure/actions/runs/4874376324
- MSSQLOutboundFirewallRule/sql
- MSSQLServerDNSAlias/sql
- MSSQLFailoverGroup/sql
- MSSQLDatabase/sql
- MSSQLServer/sql
- ResourceGroup/azure
