### PR TITLE
Fix issue 17: azure.cache: `RedisCache` MR is failing when `redisVersion` is not explicitly specified

### DIFF
--- a/apis/cache/v1beta1/zz_rediscache_types.go
+++ b/apis/cache/v1beta1/zz_rediscache_types.go
@@ -361,6 +361,7 @@ type RedisCache struct {
 	// +kubebuilder:validation:XValidation:rule="self.managementPolicy == 'ObserveOnly' || has(self.forProvider.capacity)",message="capacity is a required parameter"
 	// +kubebuilder:validation:XValidation:rule="self.managementPolicy == 'ObserveOnly' || has(self.forProvider.family)",message="family is a required parameter"
 	// +kubebuilder:validation:XValidation:rule="self.managementPolicy == 'ObserveOnly' || has(self.forProvider.location)",message="location is a required parameter"
+	// +kubebuilder:validation:XValidation:rule="self.managementPolicy == 'ObserveOnly' || has(self.forProvider.redisVersion)",message="redisVersion is a required parameter"
 	// +kubebuilder:validation:XValidation:rule="self.managementPolicy == 'ObserveOnly' || has(self.forProvider.skuName)",message="skuName is a required parameter"
 	Spec   RedisCacheSpec   `json:"spec"`
 	Status RedisCacheStatus `json:"status,omitempty"`

--- a/config/cache/config.go
+++ b/config/cache/config.go
@@ -22,4 +22,8 @@ func Configure(p *config.Provider) {
 		}
 		delete(r.References, "linked_redis_cache_location")
 	})
+
+	p.AddResourceConfigurator("azurerm_redis_cache", func(r *config.Resource) {
+		config.MarkAsRequired(r.TerraformResource, "redis_version")
+	})
 }

--- a/package/crds/cache.azure.upbound.io_rediscaches.yaml
+++ b/package/crds/cache.azure.upbound.io_rediscaches.yaml
@@ -635,6 +635,8 @@ spec:
               rule: self.managementPolicy == 'ObserveOnly' || has(self.forProvider.family)
             - message: location is a required parameter
               rule: self.managementPolicy == 'ObserveOnly' || has(self.forProvider.location)
+            - message: redisVersion is a required parameter
+              rule: self.managementPolicy == 'ObserveOnly' || has(self.forProvider.redisVersion)
             - message: skuName is a required parameter
               rule: self.managementPolicy == 'ObserveOnly' || has(self.forProvider.skuName)
           status:


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

`RedisCache` : attribute `redisVersion` marked as required using [config.MarkAsRequired](https://github.com/upbound/upjet/blob/main/pkg/config/common.go#L109) since the defaulting is done by Terraform.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azure Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/upbound/provider-azure/issues/17

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Manually: upjet.upbound.io/manual-intervention: "https://github.com/upbound/official-providers/issues/629"
<img width="655" alt="image" src="https://user-images.githubusercontent.com/114226153/236397510-e60feb9a-7094-4544-aafd-b857c0bb0773.png">

```
conditions:
  - lastTransitionTime: "2023-05-04T21:01:16Z"
    reason: Available
    status: "True"
    type: Ready
  - lastTransitionTime: "2023-05-04T20:48:57Z"
    reason: ReconcileSuccess
    status: "True"
    type: Synced
  - lastTransitionTime: "2023-05-04T21:00:49Z"
    reason: Success
    status: "True"
    type: LastAsyncOperation
  - lastTransitionTime: "2023-05-04T21:00:49Z"
    reason: Finished
    status: "True"
    type: AsyncOperation
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
