### PR TITLE
Add native provider version bump workflow

### DIFF
--- a/.github/workflows/native-provider-bump.yml
+++ b/.github/workflows/native-provider-bump.yml
@@ -1,0 +1,13 @@
+name: Native Provider Version Bump
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  open-bump-pr:
+    uses: upbound/uptest/.github/workflows/native-provider-bump.yml@main
+    with:
+      provider-source: hashicorp/azurerm
+      go-version: 1.19
+    secrets:
+      TOKEN: ${{ secrets.OFFICIAL_PROVIDERS_GA_TOKEN }}


### PR DESCRIPTION
### Description of your changes

Depends on: https://github.com/upbound/uptest/pull/67

This PR adds a workflow to check for the latest version of the hashicorp/azurerm Terraform provider and opens a version bump PR if a newer version of it is found.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested on: https://github.com/upbound/provider-aws/pull/714