### PR TITLE
KubernetesCluster: LateInit field extension

### DIFF
--- a/apis/containerservice/v1beta1/zz_generated_terraformed.go
+++ b/apis/containerservice/v1beta1/zz_generated_terraformed.go
@@ -77,7 +77,6 @@ func (tr *KubernetesCluster) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
-	opts = append(opts, resource.WithNameFilter("APIServerAccessProfile"))
 	opts = append(opts, resource.WithNameFilter("APIServerAuthorizedIPRanges"))
 	opts = append(opts, resource.WithNameFilter("KubeletIdentity"))
 	opts = append(opts, resource.WithNameFilter("MicrosoftDefender"))

--- a/apis/containerservice/v1beta1/zz_generated_terraformed.go
+++ b/apis/containerservice/v1beta1/zz_generated_terraformed.go
@@ -77,7 +77,11 @@ func (tr *KubernetesCluster) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("APIServerAccessProfile"))
+	opts = append(opts, resource.WithNameFilter("APIServerAuthorizedIPRanges"))
 	opts = append(opts, resource.WithNameFilter("KubeletIdentity"))
+	opts = append(opts, resource.WithNameFilter("MicrosoftDefender"))
+	opts = append(opts, resource.WithNameFilter("OmsAgent"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/containerservice/v1beta1/zz_kubernetescluster_types.go
+++ b/apis/containerservice/v1beta1/zz_kubernetescluster_types.go
@@ -902,6 +902,7 @@ type KubernetesClusterObservation struct {
 	// An api_server_access_profile block as defined below.
 	APIServerAccessProfile []APIServerAccessProfileObservation `json:"apiServerAccessProfile,omitempty" tf:"api_server_access_profile,omitempty"`
 
+	// Deprecated in favor of `spec.forProvider.apiServerAccessProfile[0].authorizedIpRanges`
 	APIServerAuthorizedIPRanges []*string `json:"apiServerAuthorizedIpRanges,omitempty" tf:"api_server_authorized_ip_ranges,omitempty"`
 
 	// A aci_connector_linux block as defined below. For more details, please visit Create and configure an AKS cluster to use virtual nodes.
@@ -1078,6 +1079,7 @@ type KubernetesClusterParameters struct {
 	// +kubebuilder:validation:Optional
 	APIServerAccessProfile []APIServerAccessProfileParameters `json:"apiServerAccessProfile,omitempty" tf:"api_server_access_profile,omitempty"`
 
+	// Deprecated in favor of `spec.forProvider.apiServerAccessProfile[0].authorizedIpRanges`
 	// +kubebuilder:validation:Optional
 	APIServerAuthorizedIPRanges []*string `json:"apiServerAuthorizedIpRanges,omitempty" tf:"api_server_authorized_ip_ranges,omitempty"`
 

--- a/config/containerservice/config.go
+++ b/config/containerservice/config.go
@@ -48,8 +48,8 @@ func Configure(p *config.Provider) {
 		r.Kind = "KubernetesCluster"
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"kubelet_identity", "private_link_enabled",
-				"api_server_authorized_ip_ranges", "api_server_access_profile",
-				"microsoft_defender", "oms_agent"},
+				"api_server_authorized_ip_ranges", "microsoft_defender",
+				"oms_agent"},
 		}
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
 			if kc, ok := attr["kube_config_raw"].(string); ok {
@@ -59,6 +59,7 @@ func Configure(p *config.Provider) {
 			}
 			return nil, nil
 		}
+		r.MetaResource.ArgumentDocs["api_server_authorized_ip_ranges"] = "Deprecated in favor of `spec.forProvider.apiServerAccessProfile[0].authorizedIpRanges`"
 	})
 
 	p.AddResourceConfigurator("azurerm_kubernetes_cluster_node_pool", func(r *config.Resource) {

--- a/config/containerservice/config.go
+++ b/config/containerservice/config.go
@@ -47,7 +47,9 @@ func Configure(p *config.Provider) {
 
 		r.Kind = "KubernetesCluster"
 		r.LateInitializer = config.LateInitializer{
-			IgnoredFields: []string{"kubelet_identity", "private_link_enabled"},
+			IgnoredFields: []string{"kubelet_identity", "private_link_enabled",
+				"api_server_authorized_ip_ranges", "api_server_access_profile",
+				"microsoft_defender", "oms_agent"},
 		}
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
 			if kc, ok := attr["kube_config_raw"].(string); ok {

--- a/examples/containerservice/kubernetescluster.yaml
+++ b/examples/containerservice/kubernetescluster.yaml
@@ -37,6 +37,9 @@ spec:
         testing.upbound.io/example-name: example-containerservice
     tags:
       Environment: Production
+    apiServerAccessProfile:
+      - authorizedIpRanges:
+         - 192.168.1.0/24
 
 ---
 

--- a/package/crds/containerservice.azure.upbound.io_kubernetesclusters.yaml
+++ b/package/crds/containerservice.azure.upbound.io_kubernetesclusters.yaml
@@ -257,6 +257,7 @@ spec:
                       type: object
                     type: array
                   apiServerAuthorizedIpRanges:
+                    description: Deprecated in favor of `spec.forProvider.apiServerAccessProfile[0].authorizedIpRanges`
                     items:
                       type: string
                     type: array
@@ -2194,6 +2195,7 @@ spec:
                       type: object
                     type: array
                   apiServerAuthorizedIpRanges:
+                    description: Deprecated in favor of `spec.forProvider.apiServerAccessProfile[0].authorizedIpRanges`
                     items:
                       type: string
                     type: array


### PR DESCRIPTION

<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Apparently, we missed some critical lateinit params after underlying terraform azurerm provider upgrade somewhere around `v0.26.0`->`v0.27.0`

See related Issues for the full context

* Fixes #460
* Fixes #461
* Fixes #463 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

e2e tested with new advanced bi-directional patching lab https://github.com/upbound/uxp-training/tree/main/advanced-compositions-azure/lab-d-solution

```
k get xaks
NAME                             SYNCED   READY   COMPOSITION                         AGE
platform-ref-azure-dkkwk-fm4g6   True     True    xaks.azure.platformref.upbound.io   31m
```
