### PR TITLE
Remove family label from config provider

### DIFF
--- a/package/crossplane.yaml.tmpl
+++ b/package/crossplane.yaml.tmpl
@@ -2,7 +2,7 @@ apiVersion: meta.pkg.crossplane.io/v1alpha1
 kind: Provider
 metadata:
   name: {{ .Name }}
-{{ if ne .Service "monolith" }}
+{{ if and (ne .Service "config") (ne .Service "monolith") }}
   labels:
     pkg.crossplane.io/provider-family: provider-family-{{ .ProviderName }}
 {{ end }}


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azure Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
To support Upbound Marketplace search indexing behaviour, the family label should only be applied on subpackages and not the config provider.

xref https://github.com/upbound/provider-gcp/pull/315
xref https://github.com/upbound/provider-aws/pull/728

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Build xpkg and extract the annotated layer to confirm only subpackages have the label:

```
labels:
    pkg.crossplane.io/provider-family: provider-family-azure
```
