### PR TITLE
Revert "Remove family label from config provider"

### DIFF
--- a/package/crossplane.yaml.tmpl
+++ b/package/crossplane.yaml.tmpl
@@ -2,7 +2,7 @@ apiVersion: meta.pkg.crossplane.io/v1alpha1
 kind: Provider
 metadata:
   name: {{ .Name }}
-{{ if and (ne .Service "config") (ne .Service "monolith") }}
+{{ if ne .Service "monolith" }}
   labels:
     pkg.crossplane.io/provider-family: provider-family-{{ .ProviderName }}
 {{ end }}


### PR DESCRIPTION
Reverts upbound/provider-azure#466

We need to revert these changes because while testing the Upbound reference platform packages we have figured out that when we remove the family label from the config package, Crossplane RBAC manager cannot properly define the RBAC rules on the ProviderConfigs (and other resources) that get installed with the config package.