### PR TITLE
Add dependency to Crossplane min version of v1.12.1-0

### DIFF
--- a/package/crossplane.yaml.tmpl
+++ b/package/crossplane.yaml.tmpl
@@ -21,8 +21,12 @@ metadata:
       address. This is a subpackage for the {{ .Service }} API group.
     friendly-name.meta.crossplane.io: Provider Azure ({{ .Service }})
     auth.upbound.io/group: {{ .ProviderName }}.upbound.io
-{{ if and (ne .Service "config") (ne .Service "monolith") -}}
 spec:
+{{ if ne .Service "monolith" }}
+  crossplane:
+    version: ">=v1.12.1-0"
+{{ end }}
+{{ if and (ne .Service "config") (ne .Service "monolith") }}
   dependsOn:
     - provider: {{ .XpkgRegOrg }}/provider-family-{{ .ProviderName }}
       version: "{{ .DepConstraint }}"


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azure Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #470 

This PR adds a dependency to Crossplane min version of `v1.12.1` for the family packages including the config package. The new dependency is not added to the monolithic packages.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Built 3 packages with this PR for the monolithic, config & `devices` providers. Here are the relevant metadata:
- `config`: https://explore.ggcr.dev/?image=index.docker.io%2Fulucinar%2Fprovider-family-azure%3Av0.1.0-fix470
```yaml
...
spec:
  controller: {}
  crossplane:
    version: '>=v1.12.1-0'
```

- `monolith`: https://explore.ggcr.dev/?image=index.docker.io%2Fulucinar%2Fprovider-azure%3Av0.1.0-fix470
```yaml
...
spec:
  controller: {}
```

- `devices`: https://explore.ggcr.dev/?image=index.docker.io%2Fulucinar%2Fprovider-azure-devices%3Av0.1.0-fix470
```yaml
...
spec:
  controller: {}
  crossplane:
    version: '>=v1.12.1-0'
  dependsOn:
  - provider: index.docker.io/ulucinar/provider-family-azure
    version: '>= 0.0.0-0'
```

Installation on Crossplane `1.12.1` goes fine as expected:
```shell
❯ kubectl get providers.pkg

NAME                             INSTALLED   HEALTHY   PACKAGE                                                         AGE
provider-azure-devices           True        True      index.docker.io/ulucinar/provider-azure-devices:v0.1.0-fix470   2m43s
ulucinar-provider-family-azure   True        True      index.docker.io/ulucinar/provider-family-azure:v0.1.0-fix470    2m32s
```

Installation on Crossplane `1.12.0` fails as expected:
```shell
❯ k get providerrevisions

NAME                                  HEALTHY   REVISION   IMAGE                                                           STATE    DEP-FOUND   DEP-INSTALLED   AGE
provider-azure-devices-fddcd0ad7043   False     1          index.docker.io/ulucinar/provider-azure-devices:v0.1.0-fix470   Active                               12m

❯ k get events -n default --field-selector 'involvedObject.name=provider-azure-devices-fddcd0ad7043'
LAST SEEN   TYPE      REASON              OBJECT                                                 MESSAGE
12m         Normal    BindClusterRole     providerrevision/provider-azure-devices-fddcd0ad7043   Bound system ClusterRole to provider ServiceAccount(s)
12s         Warning   ApplyClusterRoles   providerrevision/provider-azure-devices-fddcd0ad7043   cannot apply ClusterRole: cannot create object: ClusterRole.rbac.authorization.k8s.io "crossplane:provider:provider-azure-devices-fddcd0ad7043:system" is invalid: rules[0].apiGroups: Required value: resource rules must supply at least one api group
12m         Warning   LintPackage         providerrevision/provider-azure-devices-fddcd0ad7043   incompatible Crossplane version: package is not compatible with Crossplane version (v1.12.0)
6m14s       Warning   LintPackage         providerrevision/provider-azure-devices-fddcd0ad7043   incompatible Crossplane version: package is not compatible with Crossplane version (v1.12.0)
```

Also tested an upgrade scenario where a previous installation of `upbound/provider-azure-devices`, with no Crossplane version constraints, on Crossplane `v1.12.0` is upgraded with a `upbound/provider-azure-devices` package that declares a dependency to Crossplane min version `v1.12.1`. The package manager is refusing to activate the associated ProviderRevision:
```shell
❯ k get providerrevisions.pkg.crossplane.io
NAME                                          HEALTHY   REVISION   IMAGE                                                           STATE      DEP-FOUND   DEP-INSTALLED   AGE
provider-azure-devices-becc562718e4           True      1          index.docker.io/ulucinar/provider-azure-devices:v0.2.0-fix470   Inactive                               7m39s
provider-azure-devices-fddcd0ad7043           False     2          index.docker.io/ulucinar/provider-azure-devices:v0.3.0-fix470   Active                                 4m5s
ulucinar-provider-family-azure-dc8eec55cb2e   True      2          index.docker.io/ulucinar/provider-family-azure:v0.2.0-fix470    Active                                 6m54s

❯ k get events -n default --field-selector 'involvedObject.name=provider-azure-devices-fddcd0ad7043'
LAST SEEN   TYPE      REASON              OBJECT                                                 MESSAGE
25m         Warning   ApplyClusterRoles   providerrevision/provider-azure-devices-fddcd0ad7043   cannot apply ClusterRole: cannot create object: ClusterRole.rbac.authorization.k8s.io "crossplane:provider:provider-azure-devices-fddcd0ad7043:system" is invalid: rules[0].apiGroups: Required value: resource rules must supply at least one api group
5m59s       Normal    BindClusterRole     providerrevision/provider-azure-devices-fddcd0ad7043   Bound system ClusterRole to provider ServiceAccount(s)
57s         Warning   ApplyClusterRoles   providerrevision/provider-azure-devices-fddcd0ad7043   cannot apply ClusterRole: cannot create object: ClusterRole.rbac.authorization.k8s.io "crossplane:provider:provider-azure-devices-fddcd0ad7043:system" is invalid: rules[0].apiGroups: Required value: resource rules must supply at least one api group
5m50s       Warning   LintPackage         providerrevision/provider-azure-devices-fddcd0ad7043   incompatible Crossplane version: package is not compatible with Crossplane version (v1.12.0)
5m56s       Warning   SyncPackage         providerrevision/provider-azure-devices-fddcd0ad7043   cannot update annotations for package revision: Operation cannot be fulfilled on providerrevisions.pkg.crossplane.io "provider-azure-devices-fddcd0ad7043": the object has been modified; please apply your changes to the latest version and try again
```
