### PR TITLE
Scoped leader election

### DIFF
--- a/cmd/provider/alertsmanagement/zz_main.go
+++ b/cmd/provider/alertsmanagement/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-alertsmanagement",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/analysisservices/zz_main.go
+++ b/cmd/provider/analysisservices/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-analysisservices",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/apimanagement/zz_main.go
+++ b/cmd/provider/apimanagement/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-apimanagement",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/appconfiguration/zz_main.go
+++ b/cmd/provider/appconfiguration/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-appconfiguration",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/appplatform/zz_main.go
+++ b/cmd/provider/appplatform/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-appplatform",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/attestation/zz_main.go
+++ b/cmd/provider/attestation/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-attestation",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/authorization/zz_main.go
+++ b/cmd/provider/authorization/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-authorization",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/automation/zz_main.go
+++ b/cmd/provider/automation/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-automation",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/azure/zz_main.go
+++ b/cmd/provider/azure/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-azure",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/azurestackhci/zz_main.go
+++ b/cmd/provider/azurestackhci/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-azurestackhci",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/botservice/zz_main.go
+++ b/cmd/provider/botservice/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-botservice",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/cache/zz_main.go
+++ b/cmd/provider/cache/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-cache",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/cdn/zz_main.go
+++ b/cmd/provider/cdn/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-cdn",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/certificateregistration/zz_main.go
+++ b/cmd/provider/certificateregistration/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-certificateregistration",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/cognitiveservices/zz_main.go
+++ b/cmd/provider/cognitiveservices/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-cognitiveservices",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/communication/zz_main.go
+++ b/cmd/provider/communication/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-communication",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/compute/zz_main.go
+++ b/cmd/provider/compute/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-compute",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/confidentialledger/zz_main.go
+++ b/cmd/provider/confidentialledger/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-confidentialledger",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/config/zz_main.go
+++ b/cmd/provider/config/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-config",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/consumption/zz_main.go
+++ b/cmd/provider/consumption/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-consumption",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/containerregistry/zz_main.go
+++ b/cmd/provider/containerregistry/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-containerregistry",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/containerservice/zz_main.go
+++ b/cmd/provider/containerservice/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-containerservice",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/cosmosdb/zz_main.go
+++ b/cmd/provider/cosmosdb/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-cosmosdb",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/costmanagement/zz_main.go
+++ b/cmd/provider/costmanagement/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-costmanagement",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/customproviders/zz_main.go
+++ b/cmd/provider/customproviders/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-customproviders",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/databoxedge/zz_main.go
+++ b/cmd/provider/databoxedge/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-databoxedge",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/databricks/zz_main.go
+++ b/cmd/provider/databricks/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-databricks",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/datafactory/zz_main.go
+++ b/cmd/provider/datafactory/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-datafactory",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/datamigration/zz_main.go
+++ b/cmd/provider/datamigration/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-datamigration",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/dataprotection/zz_main.go
+++ b/cmd/provider/dataprotection/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-dataprotection",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/datashare/zz_main.go
+++ b/cmd/provider/datashare/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-datashare",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/dbformariadb/zz_main.go
+++ b/cmd/provider/dbformariadb/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-dbformariadb",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/dbformysql/zz_main.go
+++ b/cmd/provider/dbformysql/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-dbformysql",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/dbforpostgresql/zz_main.go
+++ b/cmd/provider/dbforpostgresql/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-dbforpostgresql",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/devices/zz_main.go
+++ b/cmd/provider/devices/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-devices",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/deviceupdate/zz_main.go
+++ b/cmd/provider/deviceupdate/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-deviceupdate",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/devtestlab/zz_main.go
+++ b/cmd/provider/devtestlab/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-devtestlab",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/digitaltwins/zz_main.go
+++ b/cmd/provider/digitaltwins/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-digitaltwins",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/elastic/zz_main.go
+++ b/cmd/provider/elastic/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-elastic",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/eventgrid/zz_main.go
+++ b/cmd/provider/eventgrid/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-eventgrid",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/eventhub/zz_main.go
+++ b/cmd/provider/eventhub/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-eventhub",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/fluidrelay/zz_main.go
+++ b/cmd/provider/fluidrelay/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-fluidrelay",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/guestconfiguration/zz_main.go
+++ b/cmd/provider/guestconfiguration/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-guestconfiguration",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/hdinsight/zz_main.go
+++ b/cmd/provider/hdinsight/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-hdinsight",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/healthbot/zz_main.go
+++ b/cmd/provider/healthbot/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-healthbot",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/healthcareapis/zz_main.go
+++ b/cmd/provider/healthcareapis/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-healthcareapis",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/insights/zz_main.go
+++ b/cmd/provider/insights/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-insights",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/iotcentral/zz_main.go
+++ b/cmd/provider/iotcentral/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-iotcentral",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/keyvault/zz_main.go
+++ b/cmd/provider/keyvault/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-keyvault",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/kusto/zz_main.go
+++ b/cmd/provider/kusto/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-kusto",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/labservices/zz_main.go
+++ b/cmd/provider/labservices/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-labservices",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/logic/zz_main.go
+++ b/cmd/provider/logic/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-logic",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/logz/zz_main.go
+++ b/cmd/provider/logz/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-logz",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/machinelearningservices/zz_main.go
+++ b/cmd/provider/machinelearningservices/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-machinelearningservices",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/maintenance/zz_main.go
+++ b/cmd/provider/maintenance/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-maintenance",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/managedidentity/zz_main.go
+++ b/cmd/provider/managedidentity/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-managedidentity",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/management/zz_main.go
+++ b/cmd/provider/management/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-management",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/maps/zz_main.go
+++ b/cmd/provider/maps/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-maps",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/marketplaceordering/zz_main.go
+++ b/cmd/provider/marketplaceordering/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-marketplaceordering",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/media/zz_main.go
+++ b/cmd/provider/media/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-media",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/mixedreality/zz_main.go
+++ b/cmd/provider/mixedreality/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-mixedreality",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/monolith/zz_main.go
+++ b/cmd/provider/monolith/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-monolith",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/netapp/zz_main.go
+++ b/cmd/provider/netapp/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-netapp",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/network/zz_main.go
+++ b/cmd/provider/network/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-network",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/notificationhubs/zz_main.go
+++ b/cmd/provider/notificationhubs/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-notificationhubs",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/operationalinsights/zz_main.go
+++ b/cmd/provider/operationalinsights/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-operationalinsights",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/operationsmanagement/zz_main.go
+++ b/cmd/provider/operationsmanagement/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-operationsmanagement",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/orbital/zz_main.go
+++ b/cmd/provider/orbital/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-orbital",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/policyinsights/zz_main.go
+++ b/cmd/provider/policyinsights/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-policyinsights",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/portal/zz_main.go
+++ b/cmd/provider/portal/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-portal",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/powerbidedicated/zz_main.go
+++ b/cmd/provider/powerbidedicated/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-powerbidedicated",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/purview/zz_main.go
+++ b/cmd/provider/purview/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-purview",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/recoveryservices/zz_main.go
+++ b/cmd/provider/recoveryservices/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-recoveryservices",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/relay/zz_main.go
+++ b/cmd/provider/relay/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-relay",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/resources/zz_main.go
+++ b/cmd/provider/resources/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-resources",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/search/zz_main.go
+++ b/cmd/provider/search/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-search",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/security/zz_main.go
+++ b/cmd/provider/security/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-security",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/securityinsights/zz_main.go
+++ b/cmd/provider/securityinsights/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-securityinsights",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/servicebus/zz_main.go
+++ b/cmd/provider/servicebus/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-servicebus",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/servicefabric/zz_main.go
+++ b/cmd/provider/servicefabric/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-servicefabric",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/servicelinker/zz_main.go
+++ b/cmd/provider/servicelinker/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-servicelinker",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/signalrservice/zz_main.go
+++ b/cmd/provider/signalrservice/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-signalrservice",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/solutions/zz_main.go
+++ b/cmd/provider/solutions/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-solutions",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/spring/zz_main.go
+++ b/cmd/provider/spring/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-spring",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/sql/zz_main.go
+++ b/cmd/provider/sql/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-sql",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/storage/zz_main.go
+++ b/cmd/provider/storage/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-storage",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/storagecache/zz_main.go
+++ b/cmd/provider/storagecache/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-storagecache",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/storagepool/zz_main.go
+++ b/cmd/provider/storagepool/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-storagepool",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/storagesync/zz_main.go
+++ b/cmd/provider/storagesync/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-storagesync",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/streamanalytics/zz_main.go
+++ b/cmd/provider/streamanalytics/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-streamanalytics",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/synapse/zz_main.go
+++ b/cmd/provider/synapse/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-synapse",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/timeseriesinsights/zz_main.go
+++ b/cmd/provider/timeseriesinsights/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-timeseriesinsights",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/cmd/provider/web/zz_main.go
+++ b/cmd/provider/web/zz_main.go
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-web",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),

--- a/hack/main.go.tmpl
+++ b/hack/main.go.tmpl
@@ -86,7 +86,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-azure",
+		LeaderElectionID:           "crossplane-leader-election-provider-azure-{{ .Group }}",
 		SyncPeriod:                 syncInterval,
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),


### PR DESCRIPTION
### Description of your changes

Updates zz_main.go.tmpl and generated files to have a family-scoped `LeaderElectionID`

Fixes https://github.com/upbound/upjet/issues/218

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

Using:

```console
 GO_LINT_ARGS=" --disable musttag " make -e reviewable test
```

### How has this code been tested

Ran locally two providers in parallel and verified they could acquire a leader lock under separate IDs:

```console
2023-06-16T12:21:24+02:00	DEBUG	provider-azure	Starting	{"sync-interval": "1h0m0s", "poll-interval": "10m0s", "max-reconcile-rate": 10}
I0616 12:21:25.554048   50994 leaderelection.go:248] attempting to acquire leader lease default/crossplane-leader-election-provider-azure-storage...
I0616 12:23:41.954852   50994 leaderelection.go:258] successfully acquired lease default/crossplane-leader-election-provider-azure-storage
```

```console
2023-06-16T12:18:16+02:00	DEBUG	provider-azure	Starting	{"sync-interval": "1h0m0s", "poll-interval": "10m0s", "max-reconcile-rate": 10}
I0616 12:18:18.427614   50733 leaderelection.go:248] attempting to acquire leader lease default/crossplane-leader-election-provider-azure-storage...
I0616 12:18:18.440031   50733 leaderelection.go:258] successfully acquired lease default/crossplane-leader-election-provider-azure-storage
```
