### PR TITLE
Remove version input from `publish-service-artifacts.yml`

### DIFF
--- a/.github/workflows/publish-service-artifacts.yml
+++ b/.github/workflows/publish-service-artifacts.yml
@@ -7,9 +7,6 @@ on:
         description: 'Subpackages to be built individually (e.g. monolith config ec2)'
         default: 'monolith'
         required: false
-      version:
-        description: 'Provider version (e.g. v0.1.0)'
-        required: true
       size:
         description: "Number of smaller provider packages to build and push with each build job"
         default: '30'
@@ -24,7 +21,6 @@ jobs:
     uses: upbound/uptest/.github/workflows/provider-publish-service-artifacts.yml@main
     with:
       subpackages: ${{ github.event.inputs.subpackages }}
-      version: ${{ github.event.inputs.version }}
       size: ${{ github.event.inputs.size }}
       concurrency: ${{ github.event.inputs.concurrency }}
     secrets:


### PR DESCRIPTION
### Description of your changes

This PR removes the version input from Publish Service Artifacts workflow.
Related PR: https://github.com/upbound/uptest/pull/125

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

Successfully validated with: https://github.com/upbound/provider-gcp/actions/runs/5333403079/jobs/9663933596