### PR TITLE
Add dependent resources to `compute.WindowsVirtualMachineScaleSet` and fix conflicts

### DIFF
--- a/apis/compute/v1beta1/zz_generated_terraformed.go
+++ b/apis/compute/v1beta1/zz_generated_terraformed.go
@@ -1561,6 +1561,7 @@ func (tr *WindowsVirtualMachineScaleSet) LateInitialize(attrs []byte) (bool, err
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("ScaleInPolicy"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/compute/v1beta1/zz_windowsvirtualmachinescaleset_types.go
+++ b/apis/compute/v1beta1/zz_windowsvirtualmachinescaleset_types.go
@@ -680,6 +680,7 @@ type WindowsVirtualMachineScaleSetObservation struct {
 	// A scale_in block as defined below.
 	ScaleIn []WindowsVirtualMachineScaleSetScaleInObservation `json:"scaleIn,omitempty" tf:"scale_in,omitempty"`
 
+	// Deprecated: scaleInPolicy will be removed in favour of the scaleIn code block.
 	ScaleInPolicy *string `json:"scaleInPolicy,omitempty" tf:"scale_in_policy,omitempty"`
 
 	// One or more secret blocks as defined below.
@@ -985,6 +986,7 @@ type WindowsVirtualMachineScaleSetParameters struct {
 	// +kubebuilder:validation:Optional
 	ScaleIn []WindowsVirtualMachineScaleSetScaleInParameters `json:"scaleIn,omitempty" tf:"scale_in,omitempty"`
 
+	// Deprecated: scaleInPolicy will be removed in favour of the scaleIn code block.
 	// +kubebuilder:validation:Optional
 	ScaleInPolicy *string `json:"scaleInPolicy,omitempty" tf:"scale_in_policy,omitempty"`
 

--- a/config/compute/config.go
+++ b/config/compute/config.go
@@ -36,6 +36,12 @@ func Configure(p *config.Provider) {
 				"virtual_machine_scale_set_id"},
 		}
 	})
+	p.AddResourceConfigurator("azurerm_windows_virtual_machine_scale_set", func(r *config.Resource) {
+		// In version 3.21.0 the `scale_in_policy` parameter was removed, and replaced by `scale_in`
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{"scale_in_policy"},
+		}
+	})
 	/* Note on testing:
 	* - create a storage account
 	* - upload a text file with *.vhd extension

--- a/config/compute/config.go
+++ b/config/compute/config.go
@@ -41,6 +41,7 @@ func Configure(p *config.Provider) {
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"scale_in_policy"},
 		}
+		r.MetaResource.ArgumentDocs["scale_in_policy"] = "Deprecated: scaleInPolicy will be removed in favour of the scaleIn code block."
 	})
 	/* Note on testing:
 	* - create a storage account

--- a/examples/compute/windowsvirtualmachinescaleset.yaml
+++ b/examples/compute/windowsvirtualmachinescaleset.yaml
@@ -17,29 +17,28 @@ spec:
     instances: 1
     location: West Europe
     networkInterface:
-    - ipConfiguration:
-      - name: internal
+      - ipConfiguration:
+          - name: internal
+            primary: true
+            subnetIdSelector:
+              matchLabels:
+                testing.upbound.io/example-name: internal
+        name: example
         primary: true
-        subnetIdSelector:
-          matchLabels:
-            testing.upbound.io/example-name: internal
-      name: example
-      primary: true
     osDisk:
-    - caching: ReadWrite
-      storageAccountType: Standard_LRS
+      - caching: ReadWrite
+        storageAccountType: Standard_LRS
     resourceGroupNameSelector:
       matchLabels:
         testing.upbound.io/example-name: example
     sku: Standard_F2
     sourceImageReference:
-    - offer: WindowsServer
-      publisher: MicrosoftWindowsServer
-      sku: 2016-Datacenter-Server-Core
-      version: latest
+      - offer: WindowsServer
+        publisher: MicrosoftWindowsServer
+        sku: 2016-Datacenter-Server-Core
+        version: latest
 
 ---
-
 apiVersion: azure.upbound.io/v1beta1
 kind: ResourceGroup
 metadata:
@@ -53,7 +52,6 @@ spec:
     location: West Europe
 
 ---
-
 apiVersion: network.azure.upbound.io/v1beta1
 kind: Subnet
 metadata:
@@ -65,7 +63,7 @@ metadata:
 spec:
   forProvider:
     addressPrefixes:
-    - 10.0.2.0/24
+      - 10.0.2.0/24
     resourceGroupNameSelector:
       matchLabels:
         testing.upbound.io/example-name: example
@@ -74,7 +72,6 @@ spec:
         testing.upbound.io/example-name: example
 
 ---
-
 apiVersion: network.azure.upbound.io/v1beta1
 kind: VirtualNetwork
 metadata:
@@ -86,17 +83,18 @@ metadata:
 spec:
   forProvider:
     addressSpace:
-    - 10.0.0.0/16
+      - 10.0.0.0/16
     location: West Europe
     resourceGroupNameSelector:
       matchLabels:
         testing.upbound.io/example-name: example
 
 ---
-
 apiVersion: v1
 kind: Secret
 metadata:
+  annotations:
+    meta.upbound.io/example-id: compute/v1beta1/windowsvirtualmachinescaleset
   name: example-secret
   namespace: upbound-system
 type: Opaque

--- a/examples/compute/windowsvirtualmachinescaleset.yaml
+++ b/examples/compute/windowsvirtualmachinescaleset.yaml
@@ -2,14 +2,17 @@ apiVersion: compute.azure.upbound.io/v1beta1
 kind: WindowsVirtualMachineScaleSet
 metadata:
   annotations:
-    upjet.upbound.io/manual-intervention: "This resource requires manual intervention."
+    uptest.upbound.io/timeout: "3600"
+    meta.upbound.io/example-id: compute/v1beta1/windowsvirtualmachinescaleset
+  labels:
+    testing.upbound.io/example-name: example
   name: example
 spec:
   forProvider:
     adminPasswordSecretRef:
-      key: example-key
+      key: password
       name: example-secret
-      namespace: crossplane-system
+      namespace: upbound-system
     adminUsername: adminuser
     instances: 1
     location: West Europe
@@ -17,19 +20,85 @@ spec:
     - ipConfiguration:
       - name: internal
         primary: true
-        subnetId: ...
-        subnetIdRef:
-          name: internal
+        subnetIdSelector:
+          matchLabels:
+            testing.upbound.io/example-name: internal
       name: example
       primary: true
     osDisk:
     - caching: ReadWrite
       storageAccountType: Standard_LRS
-    resourceGroupNameRef:
-      name: example-compute
+    resourceGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
     sku: Standard_F2
     sourceImageReference:
     - offer: WindowsServer
       publisher: MicrosoftWindowsServer
       sku: 2016-Datacenter-Server-Core
       version: latest
+
+---
+
+apiVersion: azure.upbound.io/v1beta1
+kind: ResourceGroup
+metadata:
+  annotations:
+    meta.upbound.io/example-id: compute/v1beta1/windowsvirtualmachinescaleset
+  labels:
+    testing.upbound.io/example-name: example
+  name: example
+spec:
+  forProvider:
+    location: West Europe
+
+---
+
+apiVersion: network.azure.upbound.io/v1beta1
+kind: Subnet
+metadata:
+  annotations:
+    meta.upbound.io/example-id: compute/v1beta1/windowsvirtualmachinescaleset
+  labels:
+    testing.upbound.io/example-name: internal
+  name: internal
+spec:
+  forProvider:
+    addressPrefixes:
+    - 10.0.2.0/24
+    resourceGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
+    virtualNetworkNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
+
+---
+
+apiVersion: network.azure.upbound.io/v1beta1
+kind: VirtualNetwork
+metadata:
+  annotations:
+    meta.upbound.io/example-id: compute/v1beta1/windowsvirtualmachinescaleset
+  labels:
+    testing.upbound.io/example-name: example
+  name: example
+spec:
+  forProvider:
+    addressSpace:
+    - 10.0.0.0/16
+    location: West Europe
+    resourceGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: example-secret
+  namespace: upbound-system
+type: Opaque
+data:
+  password: dGVzdFBhc3N3b3JkITEyMw== # testPassword!123

--- a/package/crds/compute.azure.upbound.io_windowsvirtualmachinescalesets.yaml
+++ b/package/crds/compute.azure.upbound.io_windowsvirtualmachinescalesets.yaml
@@ -1003,6 +1003,8 @@ spec:
                       type: object
                     type: array
                   scaleInPolicy:
+                    description: 'Deprecated: scaleInPolicy will be removed in favour
+                      of the scaleIn code block.'
                     type: string
                   secret:
                     description: One or more secret blocks as defined below.
@@ -2072,6 +2074,8 @@ spec:
                       type: object
                     type: array
                   scaleInPolicy:
+                    description: 'Deprecated: scaleInPolicy will be removed in favour
+                      of the scaleIn code block.'
                     type: string
                   secret:
                     description: One or more secret blocks as defined below.


### PR DESCRIPTION
### Description of your changes

This PR fixes the conflicting parameters and adds dependent resources to make uptestable to `compute.WindowsVirtualMachineScaleSet` resource.

Fixes: https://github.com/upbound/provider-azure/issues/487

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually and Uptest: https://github.com/upbound/provider-azure/actions/runs/5512679934
```
NAME                                     READY   SYNCED   EXTERNAL-NAME   AGE
resourcegroup.azure.upbound.io/example   True    True     example         42m

NAME                                                             READY   SYNCED   EXTERNAL-NAME   AGE
windowsvirtualmachinescaleset.compute.azure.upbound.io/example   True    True     example         8m34s

NAME                                              READY   SYNCED   EXTERNAL-NAME   AGE
virtualnetwork.network.azure.upbound.io/example   True    True     example         42m

NAME                                       READY   SYNCED   EXTERNAL-NAME   AGE
subnet.network.azure.upbound.io/internal   True    True     internal        42m
```
