### PR TITLE
Fix issue 441: MSSQLDatabase: "maintenance_configuration_name": conflicts with elastic_pool_id

### DIFF
--- a/apis/sql/v1beta1/zz_generated_terraformed.go
+++ b/apis/sql/v1beta1/zz_generated_terraformed.go
@@ -77,6 +77,8 @@ func (tr *MSSQLDatabase) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("ElasticPoolID"))
+	opts = append(opts, resource.WithNameFilter("MaintenanceConfigurationName"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/sql/config.go
+++ b/config/sql/config.go
@@ -139,6 +139,9 @@ func Configure(p *config.Provider) {
 			Type:      "MSSQLServer",
 			Extractor: rconfig.ExtractResourceIDFuncPath,
 		}
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{"maintenance_configuration_name", "elastic_pool_id"},
+		}
 	})
 
 	p.AddResourceConfigurator("azurerm_mssql_outbound_firewall_rule", func(r *config.Resource) {


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Fix next error for the MSSQLDatabase resource:
cannot run refresh: refresh failed: Conflicting configuration arguments: "maintenance_configuration_name": conflicts with elastic_pool_id

Ignored attributes:
maintenance_configuration_name
elastic_pool_id

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azure Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes: https://github.com/upbound/provider-azure/issues/441

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
- Uptest: https://github.com/upbound/provider-azure/actions/runs/5546124689
- Manual tested when we use next attribute while create resource:
    elasticPoolId: /subscriptions/XXXXXX/resourceGroups/XXXXXX-test-rg/providers/Microsoft.Sql/servers/XXXXXX-server/elasticPools/XXXXXX-elasticpool

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
