### PR TITLE
Adds Filesystem source for provider credentials source

### DIFF
--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -53,7 +53,7 @@ type ProviderConfigSpec struct {
 // ProviderCredentials required to authenticate.
 type ProviderCredentials struct {
 	// Source of the provider credentials.
-	// +kubebuilder:validation:Enum=None;Secret;UserAssignedManagedIdentity;SystemAssignedManagedIdentity;OIDCTokenFile;Upbound
+	// +kubebuilder:validation:Enum=None;Secret;UserAssignedManagedIdentity;SystemAssignedManagedIdentity;OIDCTokenFile;Upbound;Filesystem
 	Source xpv1.CredentialsSource `json:"source"`
 
 	xpv1.CommonCredentialSelectors `json:",inline"`

--- a/package/crds/azure.upbound.io_providerconfigs.yaml
+++ b/package/crds/azure.upbound.io_providerconfigs.yaml
@@ -102,6 +102,7 @@ spec:
                     - SystemAssignedManagedIdentity
                     - OIDCTokenFile
                     - Upbound
+                    - Filesystem
                     type: string
                 required:
                 - source


### PR DESCRIPTION

Signed-off-by: Francois Herbert <francois@herbert.org.nz>

### Description of your changes
Enable Filesystem as option for source of provider credentials

Fixes #503 

I have:

- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Build provider and check deployed azure providerconfig crd, new source option Filesystem available.
