### PR TITLE
Inherit golangci-lint version from `build` submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,9 @@ GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 export GOPRIVATE = github.com/upbound/*
 
 GO_REQUIRED_VERSION ?= 1.19
-GOLANGCILINT_VERSION ?= 1.50.0
+# GOLANGCILINT_VERSION is inherited from build submodule by default.
+# Uncomment below if you need to override the version.
+# GOLANGCILINT_VERSION ?= 1.53.3
 # SUBPACKAGES ?= $(shell find cmd/provider -type d -maxdepth 1 -mindepth 1 | cut -d/ -f3)
 SUBPACKAGES ?= monolith
 GO_STATIC_PACKAGES ?= $(GO_PROJECT)/cmd/generator ${SUBPACKAGES:%=$(GO_PROJECT)/cmd/provider/%}


### PR DESCRIPTION


### Description of your changes

* Motivation: golangci-lint base run was freezing on Mac M1 and `go1.20.5`. 
* Remove the version override in the Makefile with the comment and consume the latest version from the `build`
* Presumably, it was a fix around https://github.com/golangci/golangci-lint/issues/3470 helped in the latest golangci-lint release


I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

`make reviewable` with/without `.cache` 
