### PR TITLE
Update build module to consume the latest golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ export GOPRIVATE = github.com/upbound/*
 GO_REQUIRED_VERSION ?= 1.19
 # GOLANGCILINT_VERSION is inherited from build submodule by default.
 # Uncomment below if you need to override the version.
-# GOLANGCILINT_VERSION ?= 1.53.3
+# GOLANGCILINT_VERSION ?= 1.54.0
+
 # SUBPACKAGES ?= $(shell find cmd/provider -type d -maxdepth 1 -mindepth 1 | cut -d/ -f3)
 SUBPACKAGES ?= monolith
 GO_STATIC_PACKAGES ?= $(GO_PROJECT)/cmd/generator ${SUBPACKAGES:%=$(GO_PROJECT)/cmd/provider/%}


### PR DESCRIPTION


<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

* Update build module to inherit version v1.54.0
* Update comment to be inline with the rest of providers

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```
$ rm -rf .cache
$ make lint
15:30:10 [ .. ] verify go modules dependencies have expected content
all modules verified
15:30:11 [ OK ] go modules dependencies verified
15:30:11 [ .. ] installing golangci-lint-v1.54.0 darwin-arm64
15:30:12 [ OK ] installing golangci-lint-v1.54.0 darwin-arm64
15:30:12 [ .. ] golangci-lint
WARN [runner] The linter 'interfacer' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.
15:30:53 [ OK ] golangci-lint
```