### PR TITLE
Update StoreConfig description to refer to Azure instead of GCP

### DIFF
--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -22,7 +22,7 @@ type StoreConfigStatus struct {
 
 // +kubebuilder:object:root=true
 
-// A StoreConfig configures how GCP controller should store connection details.
+// A StoreConfig configures how Azure controller should store connection details.
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="TYPE",type="string",JSONPath=".spec.type"
 // +kubebuilder:printcolumn:name="DEFAULT-SCOPE",type="string",JSONPath=".spec.defaultScope"

--- a/package/crds/azure.upbound.io_storeconfigs.yaml
+++ b/package/crds/azure.upbound.io_storeconfigs.yaml
@@ -31,7 +31,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: A StoreConfig configures how GCP controller should store connection
+        description: A StoreConfig configures how Azure controller should store connection
           details.
         properties:
           apiVersion:


### PR DESCRIPTION
### Description of your changes

A helpful community member pointed me today to this small typo where the `StoreConfig` type refers to GCP instead of Azure.  You can see this error in action on https://marketplace.upbound.io/providers/upbound/provider-family-azure/latest/resources/azure.upbound.io/StoreConfig/v1alpha1.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

`make reviewable` has been run and the resultant generated CRD was updated and visually verified.  No further testing beyond that.
