### PR TITLE
[KeyVault]: Allow non RFC1123 name for Key,Secret,Certificate

### DIFF
--- a/apis/keyvault/v1beta1/zz_certificate_types.go
+++ b/apis/keyvault/v1beta1/zz_certificate_types.go
@@ -84,6 +84,9 @@ type CertificateInitParameters struct {
 	// A certificate_policy block as defined below. Changing this forces a new resource to be created.
 	CertificatePolicy []CertificatePolicyInitParameters `json:"certificatePolicy,omitempty" tf:"certificate_policy,omitempty"`
 
+	// Specifies the name of the Key Vault Certificate. Changing this forces a new resource to be created.
+	Name *string `json:"name,omitempty" tf:"name,omitempty"`
+
 	// A mapping of tags to assign to the resource.
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 }
@@ -110,6 +113,9 @@ type CertificateObservation struct {
 
 	// The ID of the Key Vault where the Certificate should be created. Changing this forces a new resource to be created.
 	KeyVaultID *string `json:"keyVaultId,omitempty" tf:"key_vault_id,omitempty"`
+
+	// Specifies the name of the Key Vault Certificate. Changing this forces a new resource to be created.
+	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
 	// The (Versioned) ID for this Key Vault Certificate. This property points to a specific version of a Key Vault Certificate, as such using this won't auto-rotate values if used in other Azure Services.
 	ResourceManagerID *string `json:"resourceManagerId,omitempty" tf:"resource_manager_id,omitempty"`
@@ -159,6 +165,10 @@ type CertificateParameters struct {
 	// Selector for a Vault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDSelector *v1.Selector `json:"keyVaultIdSelector,omitempty" tf:"-"`
+
+	// Specifies the name of the Key Vault Certificate. Changing this forces a new resource to be created.
+	// +kubebuilder:validation:Optional
+	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
 	// A mapping of tags to assign to the resource.
 	// +kubebuilder:validation:Optional
@@ -513,8 +523,9 @@ type CertificateStatus struct {
 type Certificate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              CertificateSpec   `json:"spec"`
-	Status            CertificateStatus `json:"status,omitempty"`
+	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.name) || (has(self.initProvider) && has(self.initProvider.name))",message="spec.forProvider.name is a required parameter"
+	Spec   CertificateSpec   `json:"spec"`
+	Status CertificateStatus `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/keyvault/v1beta1/zz_generated.deepcopy.go
+++ b/apis/keyvault/v1beta1/zz_generated.deepcopy.go
@@ -1141,6 +1141,11 @@ func (in *CertificateInitParameters) DeepCopyInto(out *CertificateInitParameters
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
+		*out = new(string)
+		**out = **in
+	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
 		*out = make(map[string]*string, len(*in))
@@ -1480,6 +1485,11 @@ func (in *CertificateObservation) DeepCopyInto(out *CertificateObservation) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
+		*out = new(string)
+		**out = **in
+	}
 	if in.ResourceManagerID != nil {
 		in, out := &in.ResourceManagerID, &out.ResourceManagerID
 		*out = new(string)
@@ -1574,6 +1584,11 @@ func (in *CertificateParameters) DeepCopyInto(out *CertificateParameters) {
 		in, out := &in.KeyVaultIDSelector, &out.KeyVaultIDSelector
 		*out = new(v1.Selector)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
+		*out = new(string)
+		**out = **in
 	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
@@ -1999,6 +2014,11 @@ func (in *KeyInitParameters) DeepCopyInto(out *KeyInitParameters) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
+		*out = new(string)
+		**out = **in
+	}
 	if in.NotBeforeDate != nil {
 		in, out := &in.NotBeforeDate, &out.NotBeforeDate
 		*out = new(string)
@@ -2122,6 +2142,11 @@ func (in *KeyObservation) DeepCopyInto(out *KeyObservation) {
 	}
 	if in.N != nil {
 		in, out := &in.N, &out.N
+		*out = new(string)
+		**out = **in
+	}
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
 		*out = new(string)
 		**out = **in
 	}
@@ -2253,6 +2278,11 @@ func (in *KeyParameters) DeepCopyInto(out *KeyParameters) {
 		in, out := &in.KeyVaultIDSelector, &out.KeyVaultIDSelector
 		*out = new(v1.Selector)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
+		*out = new(string)
+		**out = **in
 	}
 	if in.NotBeforeDate != nil {
 		in, out := &in.NotBeforeDate, &out.NotBeforeDate
@@ -3788,6 +3818,11 @@ func (in *SecretInitParameters) DeepCopyInto(out *SecretInitParameters) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
+		*out = new(string)
+		**out = **in
+	}
 	if in.NotBeforeDate != nil {
 		in, out := &in.NotBeforeDate, &out.NotBeforeDate
 		*out = new(string)
@@ -3876,6 +3911,11 @@ func (in *SecretObservation) DeepCopyInto(out *SecretObservation) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
+		*out = new(string)
+		**out = **in
+	}
 	if in.NotBeforeDate != nil {
 		in, out := &in.NotBeforeDate, &out.NotBeforeDate
 		*out = new(string)
@@ -3956,6 +3996,11 @@ func (in *SecretParameters) DeepCopyInto(out *SecretParameters) {
 		in, out := &in.KeyVaultIDSelector, &out.KeyVaultIDSelector
 		*out = new(v1.Selector)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
+		*out = new(string)
+		**out = **in
 	}
 	if in.NotBeforeDate != nil {
 		in, out := &in.NotBeforeDate, &out.NotBeforeDate

--- a/apis/keyvault/v1beta1/zz_key_types.go
+++ b/apis/keyvault/v1beta1/zz_key_types.go
@@ -59,6 +59,9 @@ type KeyInitParameters struct {
 	// Specifies the Key Type to use for this Key Vault Key. Possible values are EC (Elliptic Curve), EC-HSM, RSA and RSA-HSM. Changing this forces a new resource to be created.
 	KeyType *string `json:"keyType,omitempty" tf:"key_type,omitempty"`
 
+	// Specifies the name of the Key Vault Key. Changing this forces a new resource to be created.
+	Name *string `json:"name,omitempty" tf:"name,omitempty"`
+
 	// Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').
 	NotBeforeDate *string `json:"notBeforeDate,omitempty" tf:"not_before_date,omitempty"`
 
@@ -97,6 +100,9 @@ type KeyObservation struct {
 
 	// The RSA modulus of this Key Vault Key.
 	N *string `json:"n,omitempty" tf:"n,omitempty"`
+
+	// Specifies the name of the Key Vault Key. Changing this forces a new resource to be created.
+	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
 	// Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').
 	NotBeforeDate *string `json:"notBeforeDate,omitempty" tf:"not_before_date,omitempty"`
@@ -167,6 +173,10 @@ type KeyParameters struct {
 	// Selector for a Vault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDSelector *v1.Selector `json:"keyVaultIdSelector,omitempty" tf:"-"`
+
+	// Specifies the name of the Key Vault Key. Changing this forces a new resource to be created.
+	// +kubebuilder:validation:Optional
+	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
 	// Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').
 	// +kubebuilder:validation:Optional
@@ -258,6 +268,7 @@ type Key struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.keyOpts) || (has(self.initProvider) && has(self.initProvider.keyOpts))",message="spec.forProvider.keyOpts is a required parameter"
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.keyType) || (has(self.initProvider) && has(self.initProvider.keyType))",message="spec.forProvider.keyType is a required parameter"
+	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.name) || (has(self.initProvider) && has(self.initProvider.name))",message="spec.forProvider.name is a required parameter"
 	Spec   KeySpec   `json:"spec"`
 	Status KeyStatus `json:"status,omitempty"`
 }

--- a/apis/keyvault/v1beta1/zz_secret_types.go
+++ b/apis/keyvault/v1beta1/zz_secret_types.go
@@ -21,6 +21,9 @@ type SecretInitParameters struct {
 	// Expiration UTC datetime (Y-m-d'T'H:M:S'Z').
 	ExpirationDate *string `json:"expirationDate,omitempty" tf:"expiration_date,omitempty"`
 
+	// Specifies the name of the Key Vault Secret. Changing this forces a new resource to be created.
+	Name *string `json:"name,omitempty" tf:"name,omitempty"`
+
 	// Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').
 	NotBeforeDate *string `json:"notBeforeDate,omitempty" tf:"not_before_date,omitempty"`
 
@@ -41,6 +44,9 @@ type SecretObservation struct {
 
 	// The ID of the Key Vault where the Secret should be created. Changing this forces a new resource to be created.
 	KeyVaultID *string `json:"keyVaultId,omitempty" tf:"key_vault_id,omitempty"`
+
+	// Specifies the name of the Key Vault Secret. Changing this forces a new resource to be created.
+	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
 	// Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').
 	NotBeforeDate *string `json:"notBeforeDate,omitempty" tf:"not_before_date,omitempty"`
@@ -84,6 +90,10 @@ type SecretParameters struct {
 	// Selector for a Vault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDSelector *v1.Selector `json:"keyVaultIdSelector,omitempty" tf:"-"`
+
+	// Specifies the name of the Key Vault Secret. Changing this forces a new resource to be created.
+	// +kubebuilder:validation:Optional
+	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
 	// Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').
 	// +kubebuilder:validation:Optional
@@ -134,6 +144,7 @@ type SecretStatus struct {
 type Secret struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
+	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.name) || (has(self.initProvider) && has(self.initProvider.name))",message="spec.forProvider.name is a required parameter"
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.valueSecretRef)",message="spec.forProvider.valueSecretRef is a required parameter"
 	Spec   SecretSpec   `json:"spec"`
 	Status SecretStatus `json:"status,omitempty"`

--- a/config/externalname.go
+++ b/config/externalname.go
@@ -1860,10 +1860,7 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 }
 
 func keyVaultURLIDConf(resourceType string) config.ExternalName {
-	e := config.NameAsIdentifier
-	e.SetIdentifierArgumentFn = func(base map[string]any, externalName string) {
-		base["name"] = strings.Split(externalName, "/")[0]
-	}
+	e := config.IdentifierFromProvider
 	e.GetExternalNameFn = func(tfstate map[string]any) (string, error) {
 		id, ok := tfstate["id"]
 		if !ok {

--- a/examples-generated/appplatform/springcloudcertificate.yaml
+++ b/examples-generated/appplatform/springcloudcertificate.yaml
@@ -77,6 +77,7 @@ spec:
     keyVaultIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example
+    name: cert-example
 
 ---
 

--- a/examples-generated/compute/diskencryptionset.yaml
+++ b/examples-generated/compute/diskencryptionset.yaml
@@ -120,6 +120,7 @@ spec:
     keyVaultIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example
+    name: des-example-key
 
 ---
 

--- a/examples-generated/databricks/workspacecustomermanagedkey.yaml
+++ b/examples-generated/databricks/workspacecustomermanagedkey.yaml
@@ -137,6 +137,7 @@ spec:
     keyVaultIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example
+    name: example-certificate
 
 ---
 

--- a/examples-generated/dataprotection/backupinstancepostgresql.yaml
+++ b/examples-generated/dataprotection/backupinstancepostgresql.yaml
@@ -100,6 +100,7 @@ spec:
     keyVaultIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example
+    name: example
     valueSecretRef:
       key: example
       name: example-postgresql-server

--- a/examples-generated/dbforpostgresql/serverkey.yaml
+++ b/examples-generated/dbforpostgresql/serverkey.yaml
@@ -118,6 +118,7 @@ spec:
     keyVaultIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example
+    name: tfex-key
 
 ---
 

--- a/examples-generated/keyvault/certificate.yaml
+++ b/examples-generated/keyvault/certificate.yaml
@@ -20,6 +20,7 @@ spec:
     keyVaultIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example
+    name: imported-cert
 
 ---
 

--- a/examples-generated/keyvault/key.yaml
+++ b/examples-generated/keyvault/key.yaml
@@ -20,6 +20,7 @@ spec:
     keyVaultIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example
+    name: generated-certificate
     rotationPolicy:
     - automatic:
       - timeBeforeExpiry: P30D

--- a/examples-generated/keyvault/secret.yaml
+++ b/examples-generated/keyvault/secret.yaml
@@ -11,6 +11,7 @@ spec:
     keyVaultIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example
+    name: secret-sauce
     valueSecretRef:
       key: example-key
       name: example-secret

--- a/examples-generated/synapse/workspaceaadadmin.yaml
+++ b/examples-generated/synapse/workspaceaadadmin.yaml
@@ -79,6 +79,7 @@ spec:
     keyVaultIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example
+    name: workspace-encryption-key
 
 ---
 

--- a/examples-generated/synapse/workspacesqlaadadmin.yaml
+++ b/examples-generated/synapse/workspacesqlaadadmin.yaml
@@ -79,6 +79,7 @@ spec:
     keyVaultIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example
+    name: workspace-encryption-key
 
 ---
 

--- a/examples/databricks/workspacecustomermanagedkey.yaml
+++ b/examples/databricks/workspacecustomermanagedkey.yaml
@@ -130,6 +130,7 @@ metadata:
   name: examplekey
 spec:
   forProvider:
+    name: exampleKey
     keyOpts:
     - decrypt
     - encrypt

--- a/examples/dataprotection/backupinstancepostgresql.yaml
+++ b/examples/dataprotection/backupinstancepostgresql.yaml
@@ -102,6 +102,7 @@ metadata:
   name: example-backupinstancepostgresql
 spec:
   forProvider:
+    name: exampleBackupInstancePostgresql
     keyVaultIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example

--- a/examples/dbforpostgresql/server-key.yaml
+++ b/examples/dbforpostgresql/server-key.yaml
@@ -105,6 +105,7 @@ metadata:
   name: example
 spec:
   forProvider:
+    name: exampleKey
     keyOpts:
     - decrypt
     - encrypt

--- a/examples/keyvault/certificate.yaml
+++ b/examples/keyvault/certificate.yaml
@@ -8,6 +8,7 @@ metadata:
   name: uptest-${Rand.RFC1123Subdomain}
 spec:
   forProvider:
+    name: custom-Non-RFC1123Name
     keyVaultIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example-cert

--- a/examples/keyvault/key.yaml
+++ b/examples/keyvault/key.yaml
@@ -8,6 +8,7 @@ metadata:
   name: uptest-${Rand.RFC1123Subdomain}
 spec:
   forProvider:
+    name: custom-Non-RFC1123Name
     keyOpts:
       - decrypt
       - encrypt

--- a/examples/keyvault/secret.yaml
+++ b/examples/keyvault/secret.yaml
@@ -8,6 +8,7 @@ metadata:
   name: uptest-${Rand.RFC1123Subdomain}
 spec:
   forProvider:
+    name: custom-Non-RFC1123Name
     keyVaultIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example

--- a/examples/synapse/workspacesqlaadadmin.yaml
+++ b/examples/synapse/workspacesqlaadadmin.yaml
@@ -74,6 +74,7 @@ metadata:
     testing.upbound.io/example-name: wssqlaadadmin-key
   name: wssqlaadadmin-key
 spec:
+  name: workspace-encryption-key
   forProvider:
     keyOpts:
     - unwrapKey

--- a/internal/controller/keyvault/certificate/zz_controller.go
+++ b/internal/controller/keyvault/certificate/zz_controller.go
@@ -27,7 +27,6 @@ import (
 func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	name := managed.ControllerName(v1beta1.Certificate_GroupVersionKind.String())
 	var initializers managed.InitializerChain
-	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
 	if o.SecretStoreConfigGVK != nil {
 		cps = append(cps, connection.NewDetailsManager(mgr.GetClient(), *o.SecretStoreConfigGVK, connection.WithTLSConfig(o.ESSOptions.TLSConfig)))

--- a/internal/controller/keyvault/key/zz_controller.go
+++ b/internal/controller/keyvault/key/zz_controller.go
@@ -27,7 +27,6 @@ import (
 func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	name := managed.ControllerName(v1beta1.Key_GroupVersionKind.String())
 	var initializers managed.InitializerChain
-	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
 	if o.SecretStoreConfigGVK != nil {
 		cps = append(cps, connection.NewDetailsManager(mgr.GetClient(), *o.SecretStoreConfigGVK, connection.WithTLSConfig(o.ESSOptions.TLSConfig)))

--- a/internal/controller/keyvault/secret/zz_controller.go
+++ b/internal/controller/keyvault/secret/zz_controller.go
@@ -27,7 +27,6 @@ import (
 func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	name := managed.ControllerName(v1beta1.Secret_GroupVersionKind.String())
 	var initializers managed.InitializerChain
-	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
 	if o.SecretStoreConfigGVK != nil {
 		cps = append(cps, connection.NewDetailsManager(mgr.GetClient(), *o.SecretStoreConfigGVK, connection.WithTLSConfig(o.ESSOptions.TLSConfig)))

--- a/package/crds/keyvault.azure.upbound.io_certificates.yaml
+++ b/package/crds/keyvault.azure.upbound.io_certificates.yaml
@@ -351,6 +351,10 @@ spec:
                             type: string
                         type: object
                     type: object
+                  name:
+                    description: Specifies the name of the Key Vault Certificate.
+                      Changing this forces a new resource to be created.
+                    type: string
                   tags:
                     additionalProperties:
                       type: string
@@ -540,6 +544,10 @@ spec:
                           type: array
                       type: object
                     type: array
+                  name:
+                    description: Specifies the name of the Key Vault Certificate.
+                      Changing this forces a new resource to be created.
+                    type: string
                   tags:
                     additionalProperties:
                       type: string
@@ -707,6 +715,11 @@ spec:
             required:
             - forProvider
             type: object
+            x-kubernetes-validations:
+            - message: spec.forProvider.name is a required parameter
+              rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
+                || ''Update'' in self.managementPolicies) || has(self.forProvider.name)
+                || (has(self.initProvider) && has(self.initProvider.name))'
           status:
             description: CertificateStatus defines the observed state of Certificate.
             properties:
@@ -958,6 +971,10 @@ spec:
                   keyVaultId:
                     description: The ID of the Key Vault where the Certificate should
                       be created. Changing this forces a new resource to be created.
+                    type: string
+                  name:
+                    description: Specifies the name of the Key Vault Certificate.
+                      Changing this forces a new resource to be created.
                     type: string
                   resourceManagerId:
                     description: The (Versioned) ID for this Key Vault Certificate.

--- a/package/crds/keyvault.azure.upbound.io_keys.yaml
+++ b/package/crds/keyvault.azure.upbound.io_keys.yaml
@@ -171,6 +171,10 @@ spec:
                             type: string
                         type: object
                     type: object
+                  name:
+                    description: Specifies the name of the Key Vault Key. Changing
+                      this forces a new resource to be created.
+                    type: string
                   notBeforeDate:
                     description: Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').
                     type: string
@@ -248,6 +252,10 @@ spec:
                     description: Specifies the Key Type to use for this Key Vault
                       Key. Possible values are EC (Elliptic Curve), EC-HSM, RSA and
                       RSA-HSM. Changing this forces a new resource to be created.
+                    type: string
+                  name:
+                    description: Specifies the name of the Key Vault Key. Changing
+                      this forces a new resource to be created.
                     type: string
                   notBeforeDate:
                     description: Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').
@@ -456,6 +464,10 @@ spec:
               rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                 || ''Update'' in self.managementPolicies) || has(self.forProvider.keyType)
                 || (has(self.initProvider) && has(self.initProvider.keyType))'
+            - message: spec.forProvider.name is a required parameter
+              rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
+                || ''Update'' in self.managementPolicies) || has(self.forProvider.name)
+                || (has(self.initProvider) && has(self.initProvider.name))'
           status:
             description: KeyStatus defines the observed state of Key.
             properties:
@@ -501,6 +513,10 @@ spec:
                     type: string
                   "n":
                     description: The RSA modulus of this Key Vault Key.
+                    type: string
+                  name:
+                    description: Specifies the name of the Key Vault Key. Changing
+                      this forces a new resource to be created.
                     type: string
                   notBeforeDate:
                     description: Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').

--- a/package/crds/keyvault.azure.upbound.io_secrets.yaml
+++ b/package/crds/keyvault.azure.upbound.io_secrets.yaml
@@ -150,6 +150,10 @@ spec:
                             type: string
                         type: object
                     type: object
+                  name:
+                    description: Specifies the name of the Key Vault Secret. Changing
+                      this forces a new resource to be created.
+                    type: string
                   notBeforeDate:
                     description: Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').
                     type: string
@@ -194,6 +198,10 @@ spec:
                     type: string
                   expirationDate:
                     description: Expiration UTC datetime (Y-m-d'T'H:M:S'Z').
+                    type: string
+                  name:
+                    description: Specifies the name of the Key Vault Secret. Changing
+                      this forces a new resource to be created.
                     type: string
                   notBeforeDate:
                     description: Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').
@@ -366,6 +374,10 @@ spec:
             - forProvider
             type: object
             x-kubernetes-validations:
+            - message: spec.forProvider.name is a required parameter
+              rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
+                || ''Update'' in self.managementPolicies) || has(self.forProvider.name)
+                || (has(self.initProvider) && has(self.initProvider.name))'
             - message: spec.forProvider.valueSecretRef is a required parameter
               rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                 || ''Update'' in self.managementPolicies) || has(self.forProvider.valueSecretRef)'
@@ -386,6 +398,10 @@ spec:
                   keyVaultId:
                     description: The ID of the Key Vault where the Secret should be
                       created. Changing this forces a new resource to be created.
+                    type: string
+                  name:
+                    description: Specifies the name of the Key Vault Secret. Changing
+                      this forces a new resource to be created.
                     type: string
                   notBeforeDate:
                     description: Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').


### PR DESCRIPTION


<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

* Fixes https://github.com/upbound/provider-azure/issues/555
* Allows custom name to be specified at `spec.forProvider.name` removing the limitation of external resource name to be compliant with k8s object `metadata.name`
* Related test suite updates

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Creation:
```
NAME                                           READY   SYNCED   EXTERNAL-NAME                                             AGE
secret.keyvault.azure.upbound.io/uptest-yury   True    True     custom-Non-RFC1123Name/16604bec375b41eb975dff1797bf661b   7m48s
```

Import with `crossplane.io/external-name: custom-Non-RFC1123Name/16604bec375b41eb975dff1797bf661b`
```
NAME                                                    READY   SYNCED   EXTERNAL-NAME                                             AGE
secret.keyvault.azure.upbound.io/uptest-yury-imported   True    True     custom-Non-RFC1123Name/16604bec375b41eb975dff1797bf661b   50s
```
The uptest run will follow below