### PR TITLE
[management]: Fix import of ManagementGroupSubscriptionAssociation

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -1989,13 +1989,14 @@ func managementGroupSubscriptionAssociation() config.ExternalName {
 		w := strings.Split(id.(string), "/")
 		return fmt.Sprintf("%s/%s", w[len(w)-3], w[len(w)-1]), nil
 	}
-	// if we construct id according to the full path above, the underlying
-	// terraform non-deterministically fails with
-	//  "could not read properties for Management Group "example-sub""
-	// just populate the id with empty string solves it. Same happens in
-	// isolated test with terraform cli
 	e.GetIDFn = func(_ context.Context, externalName string, parameters map[string]interface{}, _ map[string]interface{}) (string, error) {
-		return "", nil
+		if len(externalName) == 0 || len(strings.Split(externalName, "/")) < 2 {
+			return "", nil
+		}
+		w := strings.Split(externalName, "/")
+		managementGroupName := w[0]
+		subscriptionId := w[1]
+		return fmt.Sprintf("/managementGroup/%s/subscription/%s", managementGroupName, subscriptionId), nil
 	}
 	return e
 }


### PR DESCRIPTION

<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azure Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
* Fixes #558
* Fix the import by fixing `GetIDFn` function for the association


I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```
NAME                                                                                READY   SYNCED   EXTERNAL-NAME                                      AGE
managementgroupsubscriptionassociation.management.azure.upbound.io/example          True    True     example-sub/<redacted>   96s
managementgroupsubscriptionassociation.management.azure.upbound.io/example-import   True    True     example-sub/<redacted>   48s
```
The `example-import` was created with `crossplane.io/external-name: example-sub/<redacted>` annotation to test the import of previously created resource. 

Uptest will follow below.
