### PR TITLE
Set async mode true for ResourceGroup

### DIFF
--- a/config/base/config.go
+++ b/config/base/config.go
@@ -36,7 +36,7 @@ func Configure(p *config.Provider) {
 	})
 
 	p.AddResourceConfigurator("azurerm_resource_group", func(r *config.Resource) {
-		r.UseAsync = false
+		r.UseAsync = true
 		r.Kind = "ResourceGroup"
 		r.ShortGroup = ""
 	})

--- a/internal/controller/azure/resourcegroup/zz_controller.go
+++ b/internal/controller/azure/resourcegroup/zz_controller.go
@@ -37,8 +37,11 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		cps = append(cps, connection.NewDetailsManager(mgr.GetClient(), *o.SecretStoreConfigGVK, connection.WithTLSConfig(o.ESSOptions.TLSConfig)))
 	}
 	eventHandler := handler.NewEventHandler(handler.WithLogger(o.Logger.WithValues("gvk", v1beta1.ResourceGroup_GroupVersionKind)))
+	ac := tjcontroller.NewAPICallbacks(mgr, xpresource.ManagedKind(v1beta1.ResourceGroup_GroupVersionKind), tjcontroller.WithEventHandler(eventHandler))
 	opts := []managed.ReconcilerOption{
-		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), o.WorkspaceStore, o.SetupFn, o.Provider.Resources["azurerm_resource_group"], tjcontroller.WithLogger(o.Logger), tjcontroller.WithConnectorEventHandler(eventHandler))),
+		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), o.WorkspaceStore, o.SetupFn, o.Provider.Resources["azurerm_resource_group"], tjcontroller.WithLogger(o.Logger), tjcontroller.WithConnectorEventHandler(eventHandler),
+			tjcontroller.WithCallbackProvider(ac),
+		)),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(o.WorkspaceStore, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),


### PR DESCRIPTION
### Description of your changes

Potential fix for: https://github.com/upbound/provider-azure/issues/577

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually:
```
status:
  atProvider:
    id: /subscriptions/038f2b7c-3265-43b8-8624-c9ad5da610a8/resourceGroups/example-resources
    location: westeurope
    tags:
      provisioner: crossplane
  conditions:
  - lastTransitionTime: "2023-10-30T13:27:02Z"
    reason: ReconcileSuccess
    status: "True"
    type: Synced
  - lastTransitionTime: "2023-10-30T13:27:59Z"
    reason: Available
    status: "True"
    type: Ready
  - lastTransitionTime: "2023-10-30T13:27:21Z"
    reason: Success
    status: "True"
    type: LastAsyncOperation
  - lastTransitionTime: "2023-10-30T13:27:21Z"
    reason: Finished
    status: "True"
    type: AsyncOperation
```
