### PR TITLE
Bump the Go version used for the e2e CI workflow to 1.21

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   e2e:
     uses: upbound/uptest/.github/workflows/pr-comment-trigger.yml@main
+    with:
+      go-version: 1.21
     secrets:
       UPTEST_CLOUD_CREDENTIALS: ${{ secrets.UPTEST_CLOUD_CREDENTIALS }}
       UPTEST_DATASOURCE: ${{ secrets.UPTEST_DATASOURCE }}


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azure Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR bumps the Go version used in the `End to End Testing` Github workflow (`e2e.yml`) to 1.21 in preparation for the validation of #592.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Will be verified in #592 once the changes are in the `main` branch.