### PR TITLE
add client certificate support for service principal auth

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -79,6 +79,29 @@ and looks like the following:
 }
 ```
 
+Alternatively, service principals credentials can also use a client certificate instead of
+a client secret. Note that the client certificate must be converted to PKCS12 format
+containing both the certificate and private key, then must be base64-encoded. Also,
+if the PKCS12 certificate is protected with a password, `clientCertificatePassword` must be
+set, it can be omitted if the certificate has no password.
+The credentials document should look like the following:
+
+```
+{
+  "clientId": "<client ID of the service principal>",
+  "clientCertificate": "<base64-encoded pkcs12 client certificate of the service principal>",
+  "clientCertificatePassword": "<password for the client certificate, can be omitted>",
+  "subscriptionId": "<subscription ID containing the service principal>",
+  "tenantId": "<tenant ID of the service principal>",
+  "activeDirectoryEndpointUrl": "https://login.microsoftonline.com",
+  "resourceManagerEndpointUrl": "https://management.azure.com/",
+  "activeDirectoryGraphResourceId": "https://graph.windows.net/",
+  "sqlManagementEndpointUrl": "https://management.core.windows.net:8443/",
+  "galleryEndpointUrl": "https://gallery.azure.com/",
+  "managementEndpointUrl": "https://management.core.windows.net/"
+}
+```
+
 As mentioned above, this authentication method involves a service principal's
 long-term credentials and is considered as less secure when compared to other
 configurations.

--- a/internal/clients/azure.go
+++ b/internal/clients/azure.go
@@ -131,7 +131,7 @@ func spAuth(ctx context.Context, pc *v1beta1.ProviderConfig, ps *terraform.Setup
 	ps.Configuration[keyClientSecret] = azureCreds[keyAzureClientSecret]
 	if clientCert, ok := azureCreds[keyAzureClientCert]; ok {
 		ps.Configuration[keyClientCert] = clientCert
-		if clientCertPass, ok2 := azureCreds[keyAzureClientCertPass]; ok2 {
+		if clientCertPass, passwordOk := azureCreds[keyAzureClientCertPass]; passwordOk {
 			ps.Configuration[keyClientCertPassword] = clientCertPass
 		}
 	}

--- a/internal/clients/azure.go
+++ b/internal/clients/azure.go
@@ -30,6 +30,8 @@ const (
 	keyAzureSubscriptionID = "subscriptionId"
 	keyAzureClientID       = "clientId"
 	keyAzureClientSecret   = "clientSecret"
+	keyAzureClientCert     = "clientCertificate"
+	keyAzureClientCertPass = "clientCertificatePassword"
 	keyAzureTenantID       = "tenantId"
 	// Terraform Provider configuration block keys
 	keyTerraformFeatures        = "features"
@@ -40,6 +42,8 @@ const (
 	keyTenantID                 = "tenant_id"
 	keyMSIEndpoint              = "msi_endpoint"
 	keyClientSecret             = "client_secret"
+	keyClientCert               = "client_certificate"
+	keyClientCertPassword       = "client_certificate_password"
 	keyEnvironment              = "environment"
 	keyOidcTokenFilePath        = "oidc_token_file_path"
 	keyUseOIDC                  = "use_oidc"
@@ -125,6 +129,12 @@ func spAuth(ctx context.Context, pc *v1beta1.ProviderConfig, ps *terraform.Setup
 	ps.Configuration[keyTenantID] = azureCreds[keyAzureTenantID]
 	ps.Configuration[keyClientID] = azureCreds[keyAzureClientID]
 	ps.Configuration[keyClientSecret] = azureCreds[keyAzureClientSecret]
+	if clientCert, ok := azureCreds[keyAzureClientCert]; ok {
+		ps.Configuration[keyClientCert] = clientCert
+		if clientCertPass, ok2 := azureCreds[keyAzureClientCertPass]; ok2 {
+			ps.Configuration[keyClientCertPassword] = clientCertPass
+		}
+	}
 	if pc.Spec.SubscriptionID != nil {
 		ps.Configuration[keySubscriptionID] = *pc.Spec.SubscriptionID
 	}


### PR DESCRIPTION
### Description of your changes
Adds client certificate support for Azure service principal credentials.
Fixes #597

Should be merged in sync with the documentation changes in https://github.com/upbound/docs/pull/280

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually tested with a Azure service principal with client certificate credentials. A Kubernetes secret is created with this principal, and was set as the provider config. An Azure resource group was successfully provisioned with this provider config.
