### PR TITLE
fix: allow publicIP to be referenced using selectors and Ref

### DIFF
--- a/apis/network/v1beta1/zz_generated.deepcopy.go
+++ b/apis/network/v1beta1/zz_generated.deepcopy.go
@@ -26822,6 +26822,16 @@ func (in *NetworkInterfaceIPConfigurationInitParameters) DeepCopyInto(out *Netwo
 		*out = new(string)
 		**out = **in
 	}
+	if in.PublicIPAddressIDRef != nil {
+		in, out := &in.PublicIPAddressIDRef, &out.PublicIPAddressIDRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.PublicIPAddressIDSelector != nil {
+		in, out := &in.PublicIPAddressIDSelector, &out.PublicIPAddressIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.SubnetID != nil {
 		in, out := &in.SubnetID, &out.SubnetID
 		*out = new(string)
@@ -26941,6 +26951,16 @@ func (in *NetworkInterfaceIPConfigurationParameters) DeepCopyInto(out *NetworkIn
 		in, out := &in.PublicIPAddressID, &out.PublicIPAddressID
 		*out = new(string)
 		**out = **in
+	}
+	if in.PublicIPAddressIDRef != nil {
+		in, out := &in.PublicIPAddressIDRef, &out.PublicIPAddressIDRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.PublicIPAddressIDSelector != nil {
+		in, out := &in.PublicIPAddressIDSelector, &out.PublicIPAddressIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.SubnetID != nil {
 		in, out := &in.SubnetID, &out.SubnetID

--- a/apis/network/v1beta1/zz_generated.resolvers.go
+++ b/apis/network/v1beta1/zz_generated.resolvers.go
@@ -2422,6 +2422,24 @@ func (mg *NetworkInterface) ResolveReferences(ctx context.Context, c client.Read
 
 	for i3 := 0; i3 < len(mg.Spec.ForProvider.IPConfiguration); i3++ {
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.IPConfiguration[i3].PublicIPAddressID),
+			Extract:      rconfig.ExtractResourceID(),
+			Reference:    mg.Spec.ForProvider.IPConfiguration[i3].PublicIPAddressIDRef,
+			Selector:     mg.Spec.ForProvider.IPConfiguration[i3].PublicIPAddressIDSelector,
+			To: reference.To{
+				List:    &PublicIPList{},
+				Managed: &PublicIP{},
+			},
+		})
+		if err != nil {
+			return errors.Wrap(err, "mg.Spec.ForProvider.IPConfiguration[i3].PublicIPAddressID")
+		}
+		mg.Spec.ForProvider.IPConfiguration[i3].PublicIPAddressID = reference.ToPtrValue(rsp.ResolvedValue)
+		mg.Spec.ForProvider.IPConfiguration[i3].PublicIPAddressIDRef = rsp.ResolvedReference
+
+	}
+	for i3 := 0; i3 < len(mg.Spec.ForProvider.IPConfiguration); i3++ {
+		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.IPConfiguration[i3].SubnetID),
 			Extract:      resource.ExtractResourceID(),
 			Reference:    mg.Spec.ForProvider.IPConfiguration[i3].SubnetIDRef,
@@ -2454,6 +2472,24 @@ func (mg *NetworkInterface) ResolveReferences(ctx context.Context, c client.Read
 	mg.Spec.ForProvider.ResourceGroupName = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.ForProvider.ResourceGroupNameRef = rsp.ResolvedReference
 
+	for i3 := 0; i3 < len(mg.Spec.InitProvider.IPConfiguration); i3++ {
+		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.IPConfiguration[i3].PublicIPAddressID),
+			Extract:      rconfig.ExtractResourceID(),
+			Reference:    mg.Spec.InitProvider.IPConfiguration[i3].PublicIPAddressIDRef,
+			Selector:     mg.Spec.InitProvider.IPConfiguration[i3].PublicIPAddressIDSelector,
+			To: reference.To{
+				List:    &PublicIPList{},
+				Managed: &PublicIP{},
+			},
+		})
+		if err != nil {
+			return errors.Wrap(err, "mg.Spec.InitProvider.IPConfiguration[i3].PublicIPAddressID")
+		}
+		mg.Spec.InitProvider.IPConfiguration[i3].PublicIPAddressID = reference.ToPtrValue(rsp.ResolvedValue)
+		mg.Spec.InitProvider.IPConfiguration[i3].PublicIPAddressIDRef = rsp.ResolvedReference
+
+	}
 	for i3 := 0; i3 < len(mg.Spec.InitProvider.IPConfiguration); i3++ {
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.IPConfiguration[i3].SubnetID),

--- a/apis/network/v1beta1/zz_networkinterface_types.go
+++ b/apis/network/v1beta1/zz_networkinterface_types.go
@@ -38,15 +38,15 @@ type NetworkInterfaceIPConfigurationInitParameters struct {
 	PrivateIPAddressVersion *string `json:"privateIpAddressVersion,omitempty" tf:"private_ip_address_version,omitempty"`
 
 	// Reference to a Public IP Address to associate with this NIC
-	// +crossplane:generate:reference:type=PublicIP
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PublicIP
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	PublicIPAddressID *string `json:"publicIpAddressId,omitempty" tf:"public_ip_address_id,omitempty"`
 
-	// Reference to a PublicIP to populate publicIpAddressId.
+	// Reference to a PublicIP in network to populate publicIpAddressId.
 	// +kubebuilder:validation:Optional
 	PublicIPAddressIDRef *v1.Reference `json:"publicIpAddressIdRef,omitempty" tf:"-"`
 
-	// Selector for a PublicIP to populate publicIpAddressId.
+	// Selector for a PublicIP in network to populate publicIpAddressId.
 	// +kubebuilder:validation:Optional
 	PublicIPAddressIDSelector *v1.Selector `json:"publicIpAddressIdSelector,omitempty" tf:"-"`
 
@@ -118,16 +118,16 @@ type NetworkInterfaceIPConfigurationParameters struct {
 	PrivateIPAddressVersion *string `json:"privateIpAddressVersion,omitempty" tf:"private_ip_address_version,omitempty"`
 
 	// Reference to a Public IP Address to associate with this NIC
-	// +crossplane:generate:reference:type=PublicIP
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PublicIP
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	PublicIPAddressID *string `json:"publicIpAddressId,omitempty" tf:"public_ip_address_id,omitempty"`
 
-	// Reference to a PublicIP to populate publicIpAddressId.
+	// Reference to a PublicIP in network to populate publicIpAddressId.
 	// +kubebuilder:validation:Optional
 	PublicIPAddressIDRef *v1.Reference `json:"publicIpAddressIdRef,omitempty" tf:"-"`
 
-	// Selector for a PublicIP to populate publicIpAddressId.
+	// Selector for a PublicIP in network to populate publicIpAddressId.
 	// +kubebuilder:validation:Optional
 	PublicIPAddressIDSelector *v1.Selector `json:"publicIpAddressIdSelector,omitempty" tf:"-"`
 

--- a/apis/network/v1beta1/zz_networkinterface_types.go
+++ b/apis/network/v1beta1/zz_networkinterface_types.go
@@ -38,7 +38,17 @@ type NetworkInterfaceIPConfigurationInitParameters struct {
 	PrivateIPAddressVersion *string `json:"privateIpAddressVersion,omitempty" tf:"private_ip_address_version,omitempty"`
 
 	// Reference to a Public IP Address to associate with this NIC
+	// +crossplane:generate:reference:type=PublicIP
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	PublicIPAddressID *string `json:"publicIpAddressId,omitempty" tf:"public_ip_address_id,omitempty"`
+
+	// Reference to a PublicIP to populate publicIpAddressId.
+	// +kubebuilder:validation:Optional
+	PublicIPAddressIDRef *v1.Reference `json:"publicIpAddressIdRef,omitempty" tf:"-"`
+
+	// Selector for a PublicIP to populate publicIpAddressId.
+	// +kubebuilder:validation:Optional
+	PublicIPAddressIDSelector *v1.Selector `json:"publicIpAddressIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Subnet where this Network Interface should be located in.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
@@ -108,8 +118,18 @@ type NetworkInterfaceIPConfigurationParameters struct {
 	PrivateIPAddressVersion *string `json:"privateIpAddressVersion,omitempty" tf:"private_ip_address_version,omitempty"`
 
 	// Reference to a Public IP Address to associate with this NIC
+	// +crossplane:generate:reference:type=PublicIP
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	PublicIPAddressID *string `json:"publicIpAddressId,omitempty" tf:"public_ip_address_id,omitempty"`
+
+	// Reference to a PublicIP to populate publicIpAddressId.
+	// +kubebuilder:validation:Optional
+	PublicIPAddressIDRef *v1.Reference `json:"publicIpAddressIdRef,omitempty" tf:"-"`
+
+	// Selector for a PublicIP to populate publicIpAddressId.
+	// +kubebuilder:validation:Optional
+	PublicIPAddressIDSelector *v1.Selector `json:"publicIpAddressIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Subnet where this Network Interface should be located in.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet

--- a/config/network/config.go
+++ b/config/network/config.go
@@ -33,8 +33,8 @@ func Configure(p *config.Provider) {
 		r.Kind = "NetworkInterface"
 
 		r.References["ip_configuration.public_ip_address_id"] = config.Reference{
-			Type:      "PublicIP",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_public_ip",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 

--- a/config/network/config.go
+++ b/config/network/config.go
@@ -31,6 +31,11 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("azurerm_network_interface", func(r *config.Resource) {
 		r.Kind = "NetworkInterface"
+
+		r.References["ip_configuration.public_ip_address_id"] = config.Reference{
+			Type:      "PublicIP",
+			Extractor: rconfig.ExtractResourceIDFuncPath,
+		}
 	})
 
 	p.AddResourceConfigurator("azurerm_lb", func(r *config.Resource) {

--- a/examples/network/networkinterface-publicip.yaml
+++ b/examples/network/networkinterface-publicip.yaml
@@ -1,7 +1,8 @@
-
 apiVersion: network.azure.upbound.io/v1beta1
 kind: PublicIP
 metadata:
+  annotations:
+    meta.upbound.io/example-id: network/v1beta1/networkinterface
   labels:
     testing.upbound.io/example-name: example-public-ip
   name: example
@@ -18,6 +19,8 @@ spec:
 apiVersion: network.azure.upbound.io/v1beta1
 kind: NetworkInterface
 metadata:
+  annotations:
+    meta.upbound.io/example-id: network/v1beta1/networkinterface
   labels:
     testing.upbound.io/example-name: example
   name: example
@@ -42,6 +45,8 @@ spec:
 apiVersion: azure.upbound.io/v1beta1
 kind: ResourceGroup
 metadata:
+  annotations:
+    meta.upbound.io/example-id: network/v1beta1/networkinterface
   labels:
     testing.upbound.io/example-name: example-network-interface
   name: example-network-interface-${Rand.RFC1123Subdomain}
@@ -54,6 +59,8 @@ spec:
 apiVersion: network.azure.upbound.io/v1beta1
 kind: Subnet
 metadata:
+  annotations:
+    meta.upbound.io/example-id: network/v1beta1/networkinterface
   labels:
     testing.upbound.io/example-name: example
   name: example
@@ -73,6 +80,8 @@ spec:
 apiVersion: network.azure.upbound.io/v1beta1
 kind: VirtualNetwork
 metadata:
+  annotations:
+    meta.upbound.io/example-id: network/v1beta1/networkinterface
   labels:
     testing.upbound.io/example-name: example
   name: example

--- a/examples/network/networkinterface-publicip.yaml
+++ b/examples/network/networkinterface-publicip.yaml
@@ -1,0 +1,86 @@
+
+apiVersion: network.azure.upbound.io/v1beta1
+kind: PublicIP
+metadata:
+  labels:
+    testing.upbound.io/example-name: example-public-ip
+  name: example
+spec:
+  forProvider:
+    allocationMethod: Static
+    location: West Europe
+    resourceGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-network-interface
+
+---
+
+apiVersion: network.azure.upbound.io/v1beta1
+kind: NetworkInterface
+metadata:
+  labels:
+    testing.upbound.io/example-name: example
+  name: example
+spec:
+  forProvider:
+    ipConfiguration:
+    - name: internal
+      privateIpAddressAllocation: Dynamic
+      subnetIdSelector:
+        matchLabels:
+          testing.upbound.io/example-name: example
+      publicIpAddressIdSelector:
+        matchLabels:
+          testing.upbound.io/example-name: example-public-ip
+    location: West Europe
+    resourceGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-network-interface
+
+---
+
+apiVersion: azure.upbound.io/v1beta1
+kind: ResourceGroup
+metadata:
+  labels:
+    testing.upbound.io/example-name: example-network-interface
+  name: example-network-interface-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    location: West Europe
+
+---
+
+apiVersion: network.azure.upbound.io/v1beta1
+kind: Subnet
+metadata:
+  labels:
+    testing.upbound.io/example-name: example
+  name: example
+spec:
+  forProvider:
+    addressPrefixes:
+    - 10.0.2.0/24
+    resourceGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-network-interface
+    virtualNetworkNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
+
+---
+
+apiVersion: network.azure.upbound.io/v1beta1
+kind: VirtualNetwork
+metadata:
+  labels:
+    testing.upbound.io/example-name: example
+  name: example
+spec:
+  forProvider:
+    addressSpace:
+    - 10.0.0.0/16
+    location: West Europe
+    resourceGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-network-interface

--- a/examples/network/networkinterface-publicip.yaml
+++ b/examples/network/networkinterface-publicip.yaml
@@ -1,29 +1,11 @@
 apiVersion: network.azure.upbound.io/v1beta1
-kind: PublicIP
-metadata:
-  annotations:
-    meta.upbound.io/example-id: network/v1beta1/networkinterface
-  labels:
-    testing.upbound.io/example-name: example-public-ip
-  name: example
-spec:
-  forProvider:
-    allocationMethod: Static
-    location: West Europe
-    resourceGroupNameSelector:
-      matchLabels:
-        testing.upbound.io/example-name: example-network-interface
-
----
-
-apiVersion: network.azure.upbound.io/v1beta1
 kind: NetworkInterface
 metadata:
   annotations:
     meta.upbound.io/example-id: network/v1beta1/networkinterface
   labels:
     testing.upbound.io/example-name: example
-  name: example
+  name: example-with-publicip
 spec:
   forProvider:
     ipConfiguration:
@@ -35,6 +17,24 @@ spec:
       publicIpAddressIdSelector:
         matchLabels:
           testing.upbound.io/example-name: example-public-ip
+    location: West Europe
+    resourceGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-network-interface
+
+---
+
+apiVersion: network.azure.upbound.io/v1beta1
+kind: PublicIP
+metadata:
+  annotations:
+    meta.upbound.io/example-id: network/v1beta1/networkinterface
+  labels:
+    testing.upbound.io/example-name: example-public-ip
+  name: example
+spec:
+  forProvider:
+    allocationMethod: Static
     location: West Europe
     resourceGroupNameSelector:
       matchLabels:

--- a/package/crds/network.azure.upbound.io_networkinterfaces.yaml
+++ b/package/crds/network.azure.upbound.io_networkinterfaces.yaml
@@ -126,6 +126,80 @@ spec:
                           description: Reference to a Public IP Address to associate
                             with this NIC
                           type: string
+                        publicIpAddressIdRef:
+                          description: Reference to a PublicIP to populate publicIpAddressId.
+                          properties:
+                            name:
+                              description: Name of the referenced object.
+                              type: string
+                            policy:
+                              description: Policies for referencing.
+                              properties:
+                                resolution:
+                                  default: Required
+                                  description: |-
+                                    Resolution specifies whether resolution of this reference is required.
+                                    The default is 'Required', which means the reconcile will fail if the
+                                    reference cannot be resolved. 'Optional' means this reference will be
+                                    a no-op if it cannot be resolved.
+                                  enum:
+                                  - Required
+                                  - Optional
+                                  type: string
+                                resolve:
+                                  description: |-
+                                    Resolve specifies when this reference should be resolved. The default
+                                    is 'IfNotPresent', which will attempt to resolve the reference only when
+                                    the corresponding field is not present. Use 'Always' to resolve the
+                                    reference on every reconcile.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        publicIpAddressIdSelector:
+                          description: Selector for a PublicIP to populate publicIpAddressId.
+                          properties:
+                            matchControllerRef:
+                              description: |-
+                                MatchControllerRef ensures an object with the same controller reference
+                                as the selecting object is selected.
+                              type: boolean
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: MatchLabels ensures an object with matching
+                                labels is selected.
+                              type: object
+                            policy:
+                              description: Policies for selection.
+                              properties:
+                                resolution:
+                                  default: Required
+                                  description: |-
+                                    Resolution specifies whether resolution of this reference is required.
+                                    The default is 'Required', which means the reconcile will fail if the
+                                    reference cannot be resolved. 'Optional' means this reference will be
+                                    a no-op if it cannot be resolved.
+                                  enum:
+                                  - Required
+                                  - Optional
+                                  type: string
+                                resolve:
+                                  description: |-
+                                    Resolve specifies when this reference should be resolved. The default
+                                    is 'IfNotPresent', which will attempt to resolve the reference only when
+                                    the corresponding field is not present. Use 'Always' to resolve the
+                                    reference on every reconcile.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  type: string
+                              type: object
+                          type: object
                         subnetId:
                           description: The ID of the Subnet where this Network Interface
                             should be located in.
@@ -366,6 +440,80 @@ spec:
                           description: Reference to a Public IP Address to associate
                             with this NIC
                           type: string
+                        publicIpAddressIdRef:
+                          description: Reference to a PublicIP to populate publicIpAddressId.
+                          properties:
+                            name:
+                              description: Name of the referenced object.
+                              type: string
+                            policy:
+                              description: Policies for referencing.
+                              properties:
+                                resolution:
+                                  default: Required
+                                  description: |-
+                                    Resolution specifies whether resolution of this reference is required.
+                                    The default is 'Required', which means the reconcile will fail if the
+                                    reference cannot be resolved. 'Optional' means this reference will be
+                                    a no-op if it cannot be resolved.
+                                  enum:
+                                  - Required
+                                  - Optional
+                                  type: string
+                                resolve:
+                                  description: |-
+                                    Resolve specifies when this reference should be resolved. The default
+                                    is 'IfNotPresent', which will attempt to resolve the reference only when
+                                    the corresponding field is not present. Use 'Always' to resolve the
+                                    reference on every reconcile.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        publicIpAddressIdSelector:
+                          description: Selector for a PublicIP to populate publicIpAddressId.
+                          properties:
+                            matchControllerRef:
+                              description: |-
+                                MatchControllerRef ensures an object with the same controller reference
+                                as the selecting object is selected.
+                              type: boolean
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: MatchLabels ensures an object with matching
+                                labels is selected.
+                              type: object
+                            policy:
+                              description: Policies for selection.
+                              properties:
+                                resolution:
+                                  default: Required
+                                  description: |-
+                                    Resolution specifies whether resolution of this reference is required.
+                                    The default is 'Required', which means the reconcile will fail if the
+                                    reference cannot be resolved. 'Optional' means this reference will be
+                                    a no-op if it cannot be resolved.
+                                  enum:
+                                  - Required
+                                  - Optional
+                                  type: string
+                                resolve:
+                                  description: |-
+                                    Resolve specifies when this reference should be resolved. The default
+                                    is 'IfNotPresent', which will attempt to resolve the reference only when
+                                    the corresponding field is not present. Use 'Always' to resolve the
+                                    reference on every reconcile.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  type: string
+                              type: object
+                          type: object
                         subnetId:
                           description: The ID of the Subnet where this Network Interface
                             should be located in.

--- a/package/crds/network.azure.upbound.io_networkinterfaces.yaml
+++ b/package/crds/network.azure.upbound.io_networkinterfaces.yaml
@@ -127,7 +127,8 @@ spec:
                             with this NIC
                           type: string
                         publicIpAddressIdRef:
-                          description: Reference to a PublicIP to populate publicIpAddressId.
+                          description: Reference to a PublicIP in network to populate
+                            publicIpAddressId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -161,7 +162,8 @@ spec:
                           - name
                           type: object
                         publicIpAddressIdSelector:
-                          description: Selector for a PublicIP to populate publicIpAddressId.
+                          description: Selector for a PublicIP in network to populate
+                            publicIpAddressId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -441,7 +443,8 @@ spec:
                             with this NIC
                           type: string
                         publicIpAddressIdRef:
-                          description: Reference to a PublicIP to populate publicIpAddressId.
+                          description: Reference to a PublicIP in network to populate
+                            publicIpAddressId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -475,7 +478,8 @@ spec:
                           - name
                           type: object
                         publicIpAddressIdSelector:
-                          description: Selector for a PublicIP to populate publicIpAddressId.
+                          description: Selector for a PublicIP in network to populate
+                            publicIpAddressId.
                           properties:
                             matchControllerRef:
                               description: |-


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
- Add Reference Extractor for PublicIPAddressId in NetworkInterface, allowing the usage on dynamic objects
- Add example yaml
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azure Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #78 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
1. Run provider locally with the changes
2. Create the objects provided in the example file
3. Network interface will be correctly created with publicAddess

<details>
  <summary>kubectl get networkinterface.network.azure.upbound.io/example -o yaml</summary>

  ```yaml
  apiVersion: network.azure.upbound.io/v1beta1
  kind: NetworkInterface
  metadata:
    annotations:
      crossplane.io/external-create-pending: "2024-02-15T11:51:47+01:00"
      crossplane.io/external-create-succeeded: "2024-02-15T11:51:47+01:00"
      crossplane.io/external-name: example
    creationTimestamp: "2024-02-15T10:49:34Z"
    finalizers:
    - finalizer.managedresource.crossplane.io
    generation: 3
    labels:
      testing.upbound.io/example-name: example
    name: example
    [...]
  spec:
    deletionPolicy: Delete
    forProvider:
      ipConfiguration:
      - name: internal
        privateIpAddressAllocation: Dynamic
        publicIpAddressId: /subscriptions/XXXX/resourceGroups/XXXX/providers/Microsoft.Network/publicIPAddresses/example
        publicIpAddressIdRef:
          name: example
        publicIpAddressIdSelector:
          matchLabels:
            testing.upbound.io/example-name: example-public-ip
  [...]
  ```

</details>